### PR TITLE
derive Clone on Tokenizer

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -159,6 +159,7 @@ pub enum Balanced {
     Bracket,
 }
 
+#[derive(Clone)]
 pub struct Tokenizer<'a, const INCLUDE_ALL: bool> {
     chars: CharIterator<'a>,
     scratch: String,

--- a/src/tokenizer/char_iterator.rs
+++ b/src/tokenizer/char_iterator.rs
@@ -2,6 +2,7 @@ use core::iter::Peekable;
 use core::ops::Range;
 use core::str::CharIndices;
 
+#[derive(Clone)]
 pub struct CharIterator<'a> {
     pub source: &'a str,
     chars: Peekable<CharIndices<'a>>,


### PR DESCRIPTION
I needed a way to back up the current state of the tokenizer in `rsnfmt`
