### PR TITLE
impl Error for tokenizer::Error

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -794,6 +794,15 @@ impl Error {
     }
 }
 
+impl Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{} at {:?}", self.kind, self.location)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ErrorKind {
     UnexpectedEof,


### PR DESCRIPTION
I noticed the `std` feature already existed.

I just added the implementation for `tokenizer::Error`

fixes #5
