### PR TITLE
Finish Error Handling

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -7,7 +7,7 @@ use core::ops::Range;
 use serde::de::{EnumAccess, MapAccess, SeqAccess, VariantAccess};
 use serde::Deserializer as _;
 
-use crate::parser::{self, Config, Event, EventKind, Nested, Parser, Primitive};
+use crate::parser::{self, Config, Event, EventKind, Name, Nested, Parser, Primitive};
 use crate::tokenizer;
 
 pub struct Deserializer<'de> {
@@ -255,7 +255,7 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
                         kind: Nested::Tuple,
                     },
                 ..
-            }) if matches!(name, Some((_, "Some"))) => {
+            }) if matches!(name, Some(Name { name: "Some", .. })) => {
                 let result = visitor.visit_some(&mut *self)?;
                 match self.parser.next().transpose()? {
                     Some(Event {
@@ -346,7 +346,7 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
                 kind: EventKind::BeginNested { name, kind },
                 location,
             }) => {
-                if name.map_or(false, |(_, name)| name != struct_name) {
+                if name.map_or(false, |name| name != struct_name) {
                     return Err(Error::new(location, ErrorKind::NameMismatch(struct_name)));
                 }
 
@@ -397,7 +397,7 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
                 kind: EventKind::BeginNested { name, kind },
                 location,
             }) => {
-                if name.map_or(false, |(_, name)| name != struct_name) {
+                if name.map_or(false, |name| name != struct_name) {
                     return Err(Error::new(location, ErrorKind::NameMismatch(struct_name)));
                 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,11 +1,14 @@
 use alloc::borrow::Cow;
-use alloc::string::String;
+use alloc::string::{String, ToString};
+use core::fmt::Display;
 use core::iter::Peekable;
+use core::ops::Range;
 
 use serde::de::{EnumAccess, MapAccess, SeqAccess, VariantAccess};
 use serde::Deserializer as _;
 
-use crate::parser::{Config, Error, Event, Nested, Parser, Primitive};
+use crate::parser::{self, Config, Event, EventKind, Nested, Parser, Primitive};
+use crate::tokenizer;
 
 pub struct Deserializer<'de> {
     parser: Peekable<Parser<'de>>,
@@ -17,6 +20,38 @@ impl<'de> Deserializer<'de> {
             parser: Parser::new(source, config.include_comments(false)).peekable(),
         }
     }
+
+    fn handle_unit(&mut self) -> Result<(), Error> {
+        match self.parser.next().transpose()? {
+            Some(Event {
+                kind:
+                    EventKind::BeginNested {
+                        kind: Nested::Tuple,
+                        ..
+                    },
+                ..
+            }) => {
+                let mut nests = 1;
+                while nests > 0 {
+                    match self.parser.next().transpose()? {
+                        Some(Event {
+                            kind: EventKind::BeginNested { .. },
+                            ..
+                        }) => nests += 1,
+                        Some(Event {
+                            kind: EventKind::EndNested,
+                            ..
+                        }) => nests -= 1,
+                        Some(_) => {}
+                        None => unreachable!("parser errors on early eof"),
+                    }
+                }
+                Ok(())
+            }
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedUnit)),
+            None => Err(Error::new(None, ErrorKind::ExpectedUnit)),
+        }
+    }
 }
 
 macro_rules! deserialize_int_impl {
@@ -26,11 +61,16 @@ macro_rules! deserialize_int_impl {
             V: serde::de::Visitor<'de>,
         {
             match self.parser.next().transpose()? {
-                Some(Event::Primitive(Primitive::Integer(value))) => {
-                    visitor.$visit_name(value.$conv_name().unwrap())
+                Some(Event {
+                    kind: EventKind::Primitive(Primitive::Integer(value)),
+                    location,
+                }) => {
+                    visitor.$visit_name(value.$conv_name().ok_or_else(|| {
+                        Error::new(location, tokenizer::ErrorKind::IntegerTooLarge)
+                    })?)
                 }
-                Some(_) => todo!("expected integer"),
-                None => todo!("unexpected eof"),
+                Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedInteger)),
+                None => Err(Error::new(None, ErrorKind::ExpectedInteger)),
             }
         }
     };
@@ -71,12 +111,16 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Bool(value))) => visitor.visit_bool(value),
-            Some(Event::Primitive(Primitive::Integer(value))) => {
-                visitor.visit_bool(!value.is_zero())
-            }
-            Some(_) => todo!("expected bool"),
-            None => todo!("unexpected eof"),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Bool(value)),
+                ..
+            }) => visitor.visit_bool(value),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Integer(value)),
+                ..
+            }) => visitor.visit_bool(!value.is_zero()),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedInteger)),
+            None => Err(Error::new(None, ErrorKind::ExpectedInteger)),
         }
     }
 
@@ -92,9 +136,16 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Float(value))) => visitor.visit_f64(value),
-            Some(_) => todo!("expected float"),
-            None => todo!("unexpected eof"),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Float(value)),
+                ..
+            }) => visitor.visit_f64(value),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Integer(value)),
+                ..
+            }) => visitor.visit_f64(value.as_f64()),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedFloat)),
+            None => Err(Error::new(None, ErrorKind::ExpectedFloat)),
         }
     }
 
@@ -103,9 +154,12 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Char(value))) => visitor.visit_char(value),
-            Some(_) => todo!("expected char"),
-            None => todo!("unexpected eof"),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Char(value)),
+                ..
+            }) => visitor.visit_char(value),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedChar)),
+            None => Err(Error::new(None, ErrorKind::ExpectedChar)),
         }
     }
 
@@ -114,19 +168,32 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Identifier(str))) => visitor.visit_borrowed_str(str),
-            Some(Event::Primitive(Primitive::String(str))) => match str {
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Identifier(str)),
+                ..
+            }) => visitor.visit_borrowed_str(str),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::String(str)),
+                ..
+            }) => match str {
                 Cow::Borrowed(str) => visitor.visit_borrowed_str(str),
                 Cow::Owned(str) => visitor.visit_string(str),
             },
-            Some(Event::Primitive(Primitive::Bytes(bytes))) => match bytes {
-                Cow::Borrowed(bytes) => {
-                    visitor.visit_borrowed_str(core::str::from_utf8(bytes).unwrap())
-                }
-                Cow::Owned(bytes) => visitor.visit_string(String::from_utf8(bytes).unwrap()),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Bytes(bytes)),
+                location,
+            }) => match bytes {
+                Cow::Borrowed(bytes) => visitor.visit_borrowed_str(
+                    core::str::from_utf8(bytes)
+                        .map_err(|_| Error::new(location, ErrorKind::InvalidUtf8))?,
+                ),
+                Cow::Owned(bytes) => visitor.visit_string(
+                    String::from_utf8(bytes)
+                        .map_err(|_| Error::new(location, ErrorKind::InvalidUtf8))?,
+                ),
             },
-            Some(_) => todo!("expected string"),
-            None => todo!("unexpected eof"),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedString)),
+            None => Err(Error::new(None, ErrorKind::ExpectedString)),
         }
     }
 
@@ -142,19 +209,26 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Identifier(str))) => {
-                visitor.visit_borrowed_bytes(str.as_bytes())
-            }
-            Some(Event::Primitive(Primitive::String(str))) => match str {
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Identifier(str)),
+                ..
+            }) => visitor.visit_borrowed_bytes(str.as_bytes()),
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::String(str)),
+                ..
+            }) => match str {
                 Cow::Borrowed(str) => visitor.visit_borrowed_bytes(str.as_bytes()),
                 Cow::Owned(str) => visitor.visit_byte_buf(str.into_bytes()),
             },
-            Some(Event::Primitive(Primitive::Bytes(bytes))) => match bytes {
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Bytes(bytes)),
+                ..
+            }) => match bytes {
                 Cow::Borrowed(bytes) => visitor.visit_borrowed_bytes(bytes),
                 Cow::Owned(bytes) => visitor.visit_byte_buf(bytes),
             },
-            Some(_) => todo!("expected bytes"),
-            None => todo!("unexpected eof"),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedBytes)),
+            None => Err(Error::new(None, ErrorKind::ExpectedBytes)),
         }
     }
 
@@ -170,22 +244,33 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::Primitive(Primitive::Identifier(str))) if str == "None" => {
-                visitor.visit_none()
-            }
-            Some(Event::BeginNested {
-                name,
-                kind: Nested::Tuple,
-            }) if name == Some("Some") => {
+            Some(Event {
+                kind: EventKind::Primitive(Primitive::Identifier(str)),
+                ..
+            }) if str == "None" => visitor.visit_none(),
+            Some(Event {
+                kind:
+                    EventKind::BeginNested {
+                        name,
+                        kind: Nested::Tuple,
+                    },
+                ..
+            }) if matches!(name, Some((_, "Some"))) => {
                 let result = visitor.visit_some(&mut *self)?;
                 match self.parser.next().transpose()? {
-                    Some(Event::EndNested) => {}
-                    _ => todo!("expected end paren"),
+                    Some(Event {
+                        kind: EventKind::EndNested,
+                        ..
+                    }) => Ok(result),
+                    Some(evt) => Err(Error::new(
+                        evt.location,
+                        ErrorKind::SomeCanOnlyContainOneValue,
+                    )),
+                    None => unreachable!("parser errors on early eof"),
                 }
-                Ok(result)
             }
-            Some(_) => todo!("expected option"),
-            None => todo!("unexpected eof"),
+            Some(evt) => Err(Error::new(evt.location, ErrorKind::ExpectedOption)),
+            None => Err(Error::new(None, ErrorKind::ExpectedOption)),
         }
     }
 
@@ -193,18 +278,9 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
     where
         V: serde::de::Visitor<'de>,
     {
-        match self.parser.next().transpose()? {
-            Some(Event::BeginNested {
-                kind: Nested::Tuple,
-                ..
-            }) => match self.parser.next().transpose()? {
-                Some(Event::EndNested) => visitor.visit_unit(),
-                Some(_) => todo!("expected unit, found tuple"),
-                None => todo!("unexpected eof"),
-            },
-            Some(_) => todo!("expected unit, found tuple"),
-            None => todo!("unexpected eof"),
-        }
+        self.handle_unit()?;
+
+        visitor.visit_unit()
     }
 
     fn deserialize_unit_struct<V>(
@@ -234,17 +310,18 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::BeginNested { kind, .. }) => {
+            Some(Event {
+                kind: EventKind::BeginNested { kind, .. },
+                location,
+            }) => {
                 if !matches!(kind, Nested::Tuple | Nested::List) {
-                    todo!("expected a tuple or list")
+                    return Err(Error::new(location, ErrorKind::ExpectedSequence));
                 }
 
                 visitor.visit_seq(self)
             }
-            Some(_other) => {
-                todo!("expected struct")
-            }
-            None => todo!("unexpected eof"),
+            Some(other) => Err(Error::new(other.location, ErrorKind::ExpectedSequence)),
+            None => Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
     }
 
@@ -265,19 +342,22 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::BeginNested { name, kind }) => {
-                if name.map_or(false, |name| name != struct_name) {
-                    todo!("struct name mismatch")
+            Some(Event {
+                kind: EventKind::BeginNested { name, kind },
+                location,
+            }) => {
+                if name.map_or(false, |(_, name)| name != struct_name) {
+                    return Err(Error::new(location, ErrorKind::NameMismatch(struct_name)));
                 }
 
                 if kind != Nested::Tuple {
-                    todo!("expected a tuple")
+                    return Err(Error::new(location, ErrorKind::ExpectedTupleStruct));
                 }
             }
-            Some(_other) => {
-                todo!("expected tuple struct")
+            Some(other) => {
+                return Err(Error::new(other.location, ErrorKind::ExpectedTupleStruct));
             }
-            None => todo!("unexpected eof"),
+            None => return Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
 
         visitor.visit_seq(self)
@@ -288,17 +368,18 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::BeginNested { kind, .. }) => {
+            Some(Event {
+                kind: EventKind::BeginNested { kind, .. },
+                location,
+            }) => {
                 if kind != Nested::Map {
-                    todo!("expected a map")
+                    return Err(Error::new(location, ErrorKind::ExpectedMap));
                 }
 
                 visitor.visit_map(self)
             }
-            Some(_other) => {
-                todo!("expected struct")
-            }
-            None => todo!("unexpected eof"),
+            Some(other) => Err(Error::new(other.location, ErrorKind::ExpectedMap)),
+            None => Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
     }
 
@@ -312,19 +393,22 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         V: serde::de::Visitor<'de>,
     {
         match self.parser.next().transpose()? {
-            Some(Event::BeginNested { name, kind }) => {
-                if name.map_or(false, |name| name != struct_name) {
-                    todo!("struct name mismatch")
+            Some(Event {
+                kind: EventKind::BeginNested { name, kind },
+                location,
+            }) => {
+                if name.map_or(false, |(_, name)| name != struct_name) {
+                    return Err(Error::new(location, ErrorKind::NameMismatch(struct_name)));
                 }
 
                 if kind != Nested::Map {
-                    todo!("expected a map")
+                    return Err(Error::new(location, ErrorKind::ExpectedMapStruct));
                 }
             }
             Some(other) => {
-                todo!("expected struct, got {other:?}")
+                return Err(Error::new(other.location, ErrorKind::ExpectedMapStruct));
             }
-            None => todo!("unexpected eof"),
+            None => return Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
 
         visitor.visit_map(self)
@@ -356,14 +440,23 @@ impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
         let mut depth = 0;
         loop {
             match self.parser.next().transpose()? {
-                Some(Event::BeginNested { .. }) => {
+                Some(Event {
+                    kind: EventKind::BeginNested { .. },
+                    ..
+                }) => {
                     depth += 1;
                 }
-                Some(Event::EndNested) => {
+                Some(Event {
+                    kind: EventKind::EndNested,
+                    ..
+                }) => {
                     depth -= 1;
                 }
-                Some(Event::Primitive(_) | Event::Comment(_)) => {}
-                None => todo!("unexpected eof"),
+                Some(Event {
+                    kind: EventKind::Primitive(_) | EventKind::Comment(_),
+                    ..
+                }) => {}
+                None => return Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
             }
 
             if depth == 0 {
@@ -383,12 +476,15 @@ impl<'de> MapAccess<'de> for Deserializer<'de> {
         K: serde::de::DeserializeSeed<'de>,
     {
         match self.parser.peek() {
-            Some(Ok(Event::EndNested)) => {
+            Some(Ok(Event {
+                kind: EventKind::EndNested,
+                ..
+            })) => {
                 self.parser.next();
                 Ok(None)
             }
             Some(_) => seed.deserialize(self).map(Some),
-            None => todo!("unexpected eof"),
+            None => Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
     }
 
@@ -408,12 +504,15 @@ impl<'de> SeqAccess<'de> for Deserializer<'de> {
         T: serde::de::DeserializeSeed<'de>,
     {
         match self.parser.peek() {
-            Some(Ok(Event::EndNested)) => {
+            Some(Ok(Event {
+                kind: EventKind::EndNested,
+                ..
+            })) => {
                 self.parser.next();
                 Ok(None)
             }
             Some(_) => seed.deserialize(self).map(Some),
-            None => todo!("unexpected eof"),
+            None => Err(Error::new(None, parser::ErrorKind::UnexpectedEof)),
         }
     }
 }
@@ -435,18 +534,7 @@ impl<'a, 'de> VariantAccess<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Self::Error> {
-        match self.parser.next().transpose()? {
-            Some(Event::BeginNested {
-                kind: Nested::Tuple,
-                ..
-            }) => match self.parser.next().transpose()? {
-                Some(Event::EndNested) => Ok(()),
-                Some(_) => todo!("expected unit, found tuple"),
-                None => todo!("unexpected eof"),
-            },
-            Some(_) => todo!("expected unit, found tuple"),
-            None => todo!("unexpected eof"),
-        }
+        self.handle_unit()
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
@@ -475,14 +563,113 @@ impl<'a, 'de> VariantAccess<'de> for &'a mut Deserializer<'de> {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct Error {
+    pub location: Option<Range<usize>>,
+    pub kind: ErrorKind,
+}
+
+impl Error {
+    pub fn new(location: impl Into<Option<Range<usize>>>, kind: impl Into<ErrorKind>) -> Self {
+        Self {
+            location: location.into(),
+            kind: kind.into(),
+        }
+    }
+}
+
 impl serde::de::Error for Error {
     fn custom<T>(msg: T) -> Self
     where
-        T: core::fmt::Display,
+        T: Display,
     {
-        todo!("custom error: {msg}")
+        Self {
+            location: None,
+            kind: ErrorKind::Message(msg.to_string()),
+        }
     }
 }
+
+impl Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if let Some(location) = &self.location {
+            write!(f, "{} at {}..{}", self.kind, location.start, location.end)
+        } else {
+            Display::fmt(&self.kind, f)
+        }
+    }
+}
+
+impl From<parser::Error> for Error {
+    fn from(err: parser::Error) -> Self {
+        Self {
+            location: Some(err.location),
+            kind: err.kind.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorKind {
+    ExpectedInteger,
+    ExpectedFloat,
+    ExpectedUnit,
+    ExpectedBool,
+    ExpectedOption,
+    ExpectedChar,
+    ExpectedString,
+    ExpectedBytes,
+    ExpectedSequence,
+    ExpectedMap,
+    ExpectedTupleStruct,
+    ExpectedMapStruct,
+    InvalidUtf8,
+    NameMismatch(&'static str),
+    SomeCanOnlyContainOneValue,
+    Parser(parser::ErrorKind),
+    Message(String),
+}
+
+impl From<parser::ErrorKind> for ErrorKind {
+    fn from(kind: parser::ErrorKind) -> Self {
+        Self::Parser(kind)
+    }
+}
+
+impl From<tokenizer::ErrorKind> for ErrorKind {
+    fn from(kind: tokenizer::ErrorKind) -> Self {
+        Self::Parser(kind.into())
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ErrorKind::Parser(parser) => Display::fmt(parser, f),
+            ErrorKind::Message(message) => f.write_str(message),
+            ErrorKind::ExpectedInteger => f.write_str("expected integer"),
+            ErrorKind::ExpectedFloat => f.write_str("expected float"),
+            ErrorKind::ExpectedBool => f.write_str("expected bool"),
+            ErrorKind::ExpectedUnit => f.write_str("expected unit"),
+            ErrorKind::ExpectedOption => f.write_str("expected option"),
+            ErrorKind::ExpectedChar => f.write_str("expected char"),
+            ErrorKind::ExpectedString => f.write_str("expected string"),
+            ErrorKind::ExpectedBytes => f.write_str("expected bytes"),
+            ErrorKind::SomeCanOnlyContainOneValue => {
+                f.write_str("Some(_) can only contain one value")
+            }
+            ErrorKind::ExpectedSequence => f.write_str("expected sequence"),
+            ErrorKind::ExpectedMap => f.write_str("expected map"),
+            ErrorKind::ExpectedTupleStruct => f.write_str("expected tuple struct"),
+            ErrorKind::ExpectedMapStruct => f.write_str("expected map struct"),
+            ErrorKind::NameMismatch(name) => write!(f, "name mismatch, expected {name}"),
+            ErrorKind::InvalidUtf8 => f.write_str("invalid utf-8"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod tokenizer;
 pub mod value;
 
 #[cfg(feature = "serde")]
-pub fn from_str<'de, D: serde::Deserialize<'de>>(source: &'de str) -> Result<D, parser::Error> {
+pub fn from_str<'de, D: serde::Deserialize<'de>>(source: &'de str) -> Result<D, de::Error> {
     let mut parser = de::Deserializer::new(source, parser::Config::default());
     // TODO verify eof
     D::deserialize(&mut parser)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -127,7 +127,10 @@ impl<'s> Parser<'s> {
                     Ok(Event::new(
                         open_location,
                         EventKind::BeginNested {
-                            name: Some((token.location, value)),
+                            name: Some(Name {
+                                location: token.location,
+                                name: value,
+                            }),
                             kind,
                         },
                     ))
@@ -390,7 +393,10 @@ impl<'s> Parser<'s> {
                                     Ok(Event::new(
                                         token.location,
                                         EventKind::BeginNested {
-                                            name: Some((open_location, identifier)),
+                                            name: Some(Name {
+                                                location: open_location,
+                                                name: identifier,
+                                            }),
                                             kind: match kind {
                                                 Balanced::Paren => Nested::Tuple,
                                                 Balanced::Brace => Nested::Map,
@@ -577,12 +583,30 @@ impl<'s> Event<'s> {
 #[derive(Debug, PartialEq, Clone)]
 pub enum EventKind<'s> {
     BeginNested {
-        name: Option<(Range<usize>, &'s str)>,
+        name: Option<Name<'s>>,
         kind: Nested,
     },
     EndNested,
     Primitive(Primitive<'s>),
     Comment(&'s str),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Name<'s> {
+    pub location: Range<usize>,
+    pub name: &'s str,
+}
+
+impl<'s> PartialEq<str> for Name<'s> {
+    fn eq(&self, other: &str) -> bool {
+        self.name == other
+    }
+}
+
+impl<'a, 's> PartialEq<&'a str> for Name<'s> {
+    fn eq(&self, other: &&'a str) -> bool {
+        self.name == *other
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,15 +71,34 @@ impl<'s> Parser<'s> {
         allowed_close: Option<Balanced>,
     ) -> Result<Event<'s>, Error> {
         match token.kind {
-            TokenKind::Integer(integer) => Ok(Event::Primitive(Primitive::Integer(integer))),
-            TokenKind::Float(float) => Ok(Event::Primitive(Primitive::Float(float))),
-            TokenKind::Bool(value) => Ok(Event::Primitive(Primitive::Bool(value))),
-            TokenKind::Character(value) => Ok(Event::Primitive(Primitive::Char(value))),
-            TokenKind::Byte(value) => Ok(Event::Primitive(Primitive::Integer(Integer::Usize(
-                value as usize,
-            )))),
-            TokenKind::String(value) => Ok(Event::Primitive(Primitive::String(value))),
-            TokenKind::Bytes(value) => Ok(Event::Primitive(Primitive::Bytes(value))),
+            TokenKind::Integer(integer) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Integer(integer)),
+            )),
+            TokenKind::Float(float) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Float(float)),
+            )),
+            TokenKind::Bool(value) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Bool(value)),
+            )),
+            TokenKind::Character(value) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Char(value)),
+            )),
+            TokenKind::Byte(value) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Integer(Integer::Usize(value as usize))),
+            )),
+            TokenKind::String(value) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::String(value)),
+            )),
+            TokenKind::Bytes(value) => Ok(Event::new(
+                token.location,
+                EventKind::Primitive(Primitive::Bytes(value)),
+            )),
             TokenKind::Identifier(value) => {
                 if matches!(
                     self.peek(),
@@ -88,7 +107,7 @@ impl<'s> Parser<'s> {
                         ..
                     })
                 ) {
-                    let Some(Ok(Token { kind: TokenKind::Open(balanced), .. })) = self.next_token() else { unreachable!("matched above") };
+                    let Some(Ok(Token { kind: TokenKind::Open(balanced), location: open_location })) = self.next_token() else { unreachable!("matched above") };
 
                     let kind = match balanced {
                         Balanced::Paren => {
@@ -105,45 +124,62 @@ impl<'s> Parser<'s> {
                         }
                     };
 
-                    Ok(Event::BeginNested {
-                        name: Some(value),
-                        kind,
-                    })
+                    Ok(Event::new(
+                        open_location,
+                        EventKind::BeginNested {
+                            name: Some((token.location, value)),
+                            kind,
+                        },
+                    ))
                 } else {
-                    Ok(Event::Primitive(Primitive::Identifier(value)))
+                    Ok(Event::new(
+                        token.location,
+                        EventKind::Primitive(Primitive::Identifier(value)),
+                    ))
                 }
             }
             TokenKind::Open(Balanced::Paren) => {
                 self.nested
                     .push(NestedState::Tuple(ListState::ExpectingValue));
-                Ok(Event::BeginNested {
-                    name: None,
-                    kind: Nested::Tuple,
-                })
+                Ok(Event::new(
+                    token.location,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Tuple,
+                    },
+                ))
             }
             TokenKind::Open(Balanced::Bracket) => {
                 self.nested
                     .push(NestedState::List(ListState::ExpectingValue));
-                Ok(Event::BeginNested {
-                    name: None,
-                    kind: Nested::List,
-                })
+                Ok(Event::new(
+                    token.location,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::List,
+                    },
+                ))
             }
             TokenKind::Open(Balanced::Brace) => {
                 self.nested.push(NestedState::Map(MapState::ExpectingKey));
-                Ok(Event::BeginNested {
-                    name: None,
-                    kind: Nested::Map,
-                })
+                Ok(Event::new(
+                    token.location,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Map,
+                    },
+                ))
             }
             TokenKind::Close(closed) if Some(closed) == allowed_close => {
                 self.nested.pop();
-                Ok(Event::EndNested)
+                Ok(Event::new(token.location, EventKind::EndNested))
             }
             TokenKind::Colon | TokenKind::Comma | TokenKind::Close(_) => {
                 Err(Error::new(token.location, ErrorKind::ExpectedValue))
             }
-            TokenKind::Comment(comment) => Ok(Event::Comment(comment)),
+            TokenKind::Comment(comment) => {
+                Ok(Event::new(token.location, EventKind::Comment(comment)))
+            }
             TokenKind::Whitespace(_) => unreachable!("disabled"),
         }
     }
@@ -153,7 +189,7 @@ impl<'s> Parser<'s> {
             ListState::ExpectingValue => {
                 let token = self.next_or_eof()?;
                 if let TokenKind::Comment(comment) = &token.kind {
-                    Ok(Event::Comment(comment))
+                    Ok(Event::new(token.location, EventKind::Comment(comment)))
                 } else {
                     *self.nested.last_mut().expect("required for this fn") =
                         NestedState::list(end, ListState::ExpectingComma);
@@ -161,16 +197,18 @@ impl<'s> Parser<'s> {
                 }
             }
             ListState::ExpectingComma => match self.next_token_parts()? {
-                (_, Some(TokenKind::Close(closed))) if closed == end => {
+                (location, Some(TokenKind::Close(closed))) if closed == end => {
                     self.nested.pop();
-                    Ok(Event::EndNested)
+                    Ok(Event::new(location, EventKind::EndNested))
                 }
                 (_, Some(TokenKind::Comma)) => {
                     *self.nested.last_mut().expect("required for this fn") =
                         NestedState::list(end, ListState::ExpectingValue);
                     self.parse_sequence(ListState::ExpectingValue, end)
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
                 (location, _) => Err(Error::new(
                     location,
                     ErrorKind::ExpectedCommaOrEnd(end.into()),
@@ -189,8 +227,8 @@ impl<'s> Parser<'s> {
             MapState::ExpectingKey => match self.next_token().transpose()? {
                 Some(Token {
                     kind: TokenKind::Comment(comment),
-                    ..
-                }) => Ok(Event::Comment(comment)),
+                    location,
+                }) => Ok(Event::new(location, EventKind::Comment(comment))),
                 Some(token) => {
                     *self.map_state_mut() = MapState::ExpectingColon;
                     self.parse_token(token, Some(Balanced::Brace))
@@ -205,14 +243,16 @@ impl<'s> Parser<'s> {
                     *self.map_state_mut() = MapState::ExpectingValue;
                     self.parse_map(MapState::ExpectingValue)
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
                 (location, _) => Err(Error::new(location, ErrorKind::ExpectedColon)),
             },
             MapState::ExpectingValue => match self.next_token().transpose()? {
                 Some(Token {
                     kind: TokenKind::Comment(comment),
-                    ..
-                }) => Ok(Event::Comment(comment)),
+                    location,
+                }) => Ok(Event::new(location, EventKind::Comment(comment))),
                 Some(token) => {
                     *self.map_state_mut() = MapState::ExpectingComma;
                     self.parse_token(token, None)
@@ -223,15 +263,17 @@ impl<'s> Parser<'s> {
                 )),
             },
             MapState::ExpectingComma => match self.next_token_parts()? {
-                (_, Some(TokenKind::Close(closed))) if closed == Balanced::Brace => {
+                (location, Some(TokenKind::Close(closed))) if closed == Balanced::Brace => {
                     self.nested.pop();
-                    Ok(Event::EndNested)
+                    Ok(Event::new(location, EventKind::EndNested))
                 }
                 (_, Some(TokenKind::Comma)) => {
                     *self.map_state_mut() = MapState::ExpectingKey;
                     self.parse_map(MapState::ExpectingKey)
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
                 (location, _) => Err(Error::new(
                     location,
                     ErrorKind::ExpectedCommaOrEnd(Nested::Map),
@@ -243,14 +285,19 @@ impl<'s> Parser<'s> {
     fn parse_implicit_map(&mut self, state: MapState) -> Result<Event<'s>, Error> {
         match state {
             MapState::ExpectingKey => match self.next_token_parts()? {
-                (_, Some(TokenKind::Identifier(key))) => {
+                (location, Some(TokenKind::Identifier(key))) => {
                     self.root_state = State::ImplicitMap(MapState::ExpectingColon);
-                    Ok(Event::Primitive(Primitive::Identifier(key)))
+                    Ok(Event::new(
+                        location,
+                        EventKind::Primitive(Primitive::Identifier(key)),
+                    ))
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
-                (_, None) => {
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
+                (location, None) => {
                     self.root_state = State::Finished;
-                    Ok(Event::EndNested)
+                    Ok(Event::new(location, EventKind::EndNested))
                 }
                 (location, _) => Err(Error::new(location, ErrorKind::ExpectedKey)),
             },
@@ -259,14 +306,16 @@ impl<'s> Parser<'s> {
                     self.root_state = State::ImplicitMap(MapState::ExpectingValue);
                     self.parse_implicit_map(MapState::ExpectingValue)
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
                 (location, _) => Err(Error::new(location, ErrorKind::ExpectedColon)),
             },
             MapState::ExpectingValue => match self.next_token().transpose()? {
                 Some(Token {
                     kind: TokenKind::Comment(comment),
-                    ..
-                }) => Ok(Event::Comment(comment)),
+                    location,
+                }) => Ok(Event::new(location, EventKind::Comment(comment))),
                 Some(token) => {
                     self.root_state = State::ImplicitMap(MapState::ExpectingComma);
                     self.parse_token(token, None)
@@ -277,22 +326,27 @@ impl<'s> Parser<'s> {
                 )),
             },
             MapState::ExpectingComma => match self.next_token_parts()? {
-                (_, Some(TokenKind::Close(closed))) if closed == Balanced::Brace => {
+                (location, Some(TokenKind::Close(closed))) if closed == Balanced::Brace => {
                     self.root_state = State::Finished;
-                    Ok(Event::EndNested)
+                    Ok(Event::new(location, EventKind::EndNested))
                 }
                 (_, Some(TokenKind::Comma)) => {
                     self.root_state = State::ImplicitMap(MapState::ExpectingKey);
                     self.parse_implicit_map(MapState::ExpectingKey)
                 }
-                (_, Some(TokenKind::Identifier(key))) => {
+                (location, Some(TokenKind::Identifier(key))) => {
                     self.root_state = State::ImplicitMap(MapState::ExpectingColon);
-                    Ok(Event::Primitive(Primitive::Identifier(key)))
+                    Ok(Event::new(
+                        location,
+                        EventKind::Primitive(Primitive::Identifier(key)),
+                    ))
                 }
-                (_, Some(TokenKind::Comment(comment))) => Ok(Event::Comment(comment)),
-                (_, None) => {
+                (location, Some(TokenKind::Comment(comment))) => {
+                    Ok(Event::new(location, EventKind::Comment(comment)))
+                }
+                (location, None) => {
                     self.root_state = State::Finished;
-                    Ok(Event::EndNested)
+                    Ok(Event::new(location, EventKind::EndNested))
                 }
                 (location, _) => Err(Error::new(location, ErrorKind::ExpectedKey)),
             },
@@ -312,41 +366,53 @@ impl<'s> Parser<'s> {
                             let TokenKind::Identifier(identifier) = token.kind
                                 else { unreachable!("just matched")};
                             match self.peek() {
-                                Some(token) if matches!(token.kind, TokenKind::Colon) => {
+                                Some(colon) if matches!(colon.kind, TokenKind::Colon) => {
                                     // Switch to parsing an implicit map
-                                    self.root_state = State::StartingImplicitMap(identifier);
-                                    Ok(Event::BeginNested {
-                                        name: None,
-                                        kind: Nested::Map,
-                                    })
+                                    self.root_state =
+                                        State::StartingImplicitMap((token.location, identifier));
+                                    Ok(Event::new(
+                                        0..0,
+                                        EventKind::BeginNested {
+                                            name: None,
+                                            kind: Nested::Map,
+                                        },
+                                    ))
                                 }
-                                Some(token)
+                                Some(open)
                                     if matches!(
-                                        token.kind,
+                                        open.kind,
                                         TokenKind::Open(Balanced::Brace | Balanced::Paren,)
                                     ) =>
                                 {
-                                    let Some(Ok(Token{ kind: TokenKind::Open(kind), ..})) = self.next_token()
+                                    let Some(Ok(Token{ kind: TokenKind::Open(kind), location: open_location})) = self.next_token()
                                         else { unreachable!("just peeked") };
                                     self.root_state = State::Finished;
-                                    Ok(Event::BeginNested {
-                                        name: Some(identifier),
-                                        kind: match kind {
-                                            Balanced::Paren => Nested::Tuple,
-                                            Balanced::Brace => Nested::Map,
-                                            Balanced::Bracket => {
-                                                unreachable!("not matched in peek")
-                                            }
+                                    Ok(Event::new(
+                                        token.location,
+                                        EventKind::BeginNested {
+                                            name: Some((open_location, identifier)),
+                                            kind: match kind {
+                                                Balanced::Paren => Nested::Tuple,
+                                                Balanced::Brace => Nested::Map,
+                                                Balanced::Bracket => {
+                                                    unreachable!("not matched in peek")
+                                                }
+                                            },
                                         },
-                                    })
+                                    ))
                                 }
                                 _ => {
                                     self.root_state = State::Finished;
-                                    Ok(Event::Primitive(Primitive::Identifier(identifier)))
+                                    Ok(Event::new(
+                                        token.location,
+                                        EventKind::Primitive(Primitive::Identifier(identifier)),
+                                    ))
                                 }
                             }
                         }
-                        TokenKind::Comment(comment) => Ok(Event::Comment(comment)),
+                        TokenKind::Comment(comment) => {
+                            Ok(Event::new(token.location, EventKind::Comment(comment)))
+                        }
                         _ => {
                             self.root_state = State::Finished;
                             self.parse_token(token, None)
@@ -354,14 +420,19 @@ impl<'s> Parser<'s> {
                     }
                 }
                 State::StartingImplicitMap(_) => {
-                    let State::StartingImplicitMap(first_key) = mem::replace(&mut self.root_state, State::ImplicitMap(MapState::ExpectingColon))
+                    let State::StartingImplicitMap((location, identifier)) = mem::replace(&mut self.root_state, State::ImplicitMap(MapState::ExpectingColon))
                         else { unreachable!("just matched") };
-                    Ok(Event::Primitive(Primitive::Identifier(first_key)))
+                    Ok(Event::new(
+                        location,
+                        EventKind::Primitive(Primitive::Identifier(identifier)),
+                    ))
                 }
                 State::ImplicitMap(state) => self.parse_implicit_map(*state),
                 State::Finished => match self.next_token()? {
                     Ok(token) => match token.kind {
-                        TokenKind::Comment(comment) => Ok(Event::Comment(comment)),
+                        TokenKind::Comment(comment) => {
+                            Ok(Event::new(token.location, EventKind::Comment(comment)))
+                        }
                         TokenKind::Whitespace(_) => unreachable!("disabled"),
                         _ => Err(Error::new(token.location, ErrorKind::TrailingData)),
                     },
@@ -382,7 +453,15 @@ impl<'s> Iterator for Parser<'s> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let event = self.next_event()?;
-            if !matches!(event, Ok(Event::Comment(_))) || self.config.include_comments {
+            if self.config.include_comments
+                || !matches!(
+                    event,
+                    Ok(Event {
+                        kind: EventKind::Comment(_),
+                        ..
+                    })
+                )
+            {
                 break Some(event);
             } else {
                 // Eat the comment
@@ -413,7 +492,7 @@ impl Config {
 #[derive(Debug, Clone, Eq, PartialEq)]
 enum State<'s> {
     AtStart,
-    StartingImplicitMap(&'s str),
+    StartingImplicitMap((Range<usize>, &'s str)),
     ImplicitMap(MapState),
     Finished,
 }
@@ -435,19 +514,7 @@ impl std::error::Error for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        match &self.kind {
-            ErrorKind::Tokenizer(err) => Display::fmt(err, f),
-            ErrorKind::UnexpectedEof => f.write_str("unexpected end of file"),
-            ErrorKind::ExpectedValue => f.write_str("a value was expected"),
-            ErrorKind::ExpectedCommaOrEnd(nested) => {
-                write!(f, "expected `,` or {}", nested.err_display())
-            }
-            ErrorKind::ExpectedColon => f.write_str("expected `:`"),
-            ErrorKind::ExpectedKey => f.write_str("expected map key"),
-            ErrorKind::TrailingData => f.write_str(
-                "source contained extra trailing data after a value was completely read",
-            ),
-        }
+        Display::fmt(&self.kind, f)
     }
 }
 
@@ -455,7 +522,7 @@ impl From<tokenizer::Error> for Error {
     fn from(err: tokenizer::Error) -> Self {
         Self {
             location: err.location,
-            kind: ErrorKind::Tokenizer(err.kind),
+            kind: err.kind.into(),
         }
     }
 }
@@ -471,9 +538,48 @@ pub enum ErrorKind {
     TrailingData,
 }
 
+impl From<tokenizer::ErrorKind> for ErrorKind {
+    fn from(kind: tokenizer::ErrorKind) -> Self {
+        Self::Tokenizer(kind)
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ErrorKind::Tokenizer(err) => Display::fmt(err, f),
+            ErrorKind::UnexpectedEof => f.write_str("unexpected end of file"),
+            ErrorKind::ExpectedValue => f.write_str("a value was expected"),
+            ErrorKind::ExpectedCommaOrEnd(nested) => {
+                write!(f, "expected `,` or {}", nested.err_display())
+            }
+            ErrorKind::ExpectedColon => f.write_str("expected `:`"),
+            ErrorKind::ExpectedKey => f.write_str("expected map key"),
+            ErrorKind::TrailingData => f.write_str(
+                "source contained extra trailing data after a value was completely read",
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Event<'s> {
+    pub location: Range<usize>,
+    pub kind: EventKind<'s>,
+}
+
+impl<'s> Event<'s> {
+    pub fn new(location: Range<usize>, kind: EventKind<'s>) -> Self {
+        Self { location, kind }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
-pub enum Event<'s> {
-    BeginNested { name: Option<&'s str>, kind: Nested },
+pub enum EventKind<'s> {
+    BeginNested {
+        name: Option<(Range<usize>, &'s str)>,
+        kind: Nested,
+    },
     EndNested,
     Primitive(Primitive<'s>),
     Comment(&'s str),
@@ -559,14 +665,26 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::List
-                },
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(3))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::List
+                    }
+                ),
+                Event::new(
+                    1..2,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(
+                    5..6,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(3)))
+                ),
+                Event::new(6..7, EventKind::EndNested),
             ]
         );
         let events = Parser::new("[1,2,3,]", Config::default())
@@ -575,14 +693,26 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::List
-                },
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(3))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::List
+                    }
+                ),
+                Event::new(
+                    1..2,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(
+                    5..6,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(3)))
+                ),
+                Event::new(7..8, EventKind::EndNested),
             ]
         );
     }
@@ -595,14 +725,26 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::Tuple
-                },
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(3))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Tuple
+                    }
+                ),
+                Event::new(
+                    1..2,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(
+                    5..6,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(3)))
+                ),
+                Event::new(6..7, EventKind::EndNested),
             ]
         );
         let events = Parser::new("(1,2,3,)", Config::default())
@@ -611,14 +753,26 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::Tuple
-                },
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::Primitive(Primitive::Integer(Integer::Usize(3))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Tuple
+                    }
+                ),
+                Event::new(
+                    1..2,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(
+                    5..6,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(3)))
+                ),
+                Event::new(7..8, EventKind::EndNested),
             ]
         );
     }
@@ -631,15 +785,24 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::Map
-                },
-                Event::Primitive(Primitive::Identifier("a")),
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Identifier("b")),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Map
+                    }
+                ),
+                Event::new(1..2, EventKind::Primitive(Primitive::Identifier("a"))),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(5..6, EventKind::Primitive(Primitive::Identifier("b"))),
+                Event::new(
+                    7..8,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(8..9, EventKind::EndNested),
             ]
         );
         let events = Parser::new("{a:1,b:2,}", Config::default())
@@ -648,15 +811,24 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::Map
-                },
-                Event::Primitive(Primitive::Identifier("a")),
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Primitive(Primitive::Identifier("b")),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::EndNested,
+                Event::new(
+                    0..1,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Map
+                    }
+                ),
+                Event::new(1..2, EventKind::Primitive(Primitive::Identifier("a"))),
+                Event::new(
+                    3..4,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(5..6, EventKind::Primitive(Primitive::Identifier("b"))),
+                Event::new(
+                    7..8,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(9..10, EventKind::EndNested),
             ]
         );
     }
@@ -672,35 +844,50 @@ mod tests {
         assert_eq!(
             &events,
             &[
-                Event::Comment("/**/"),
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::Map
-                },
-                Event::Comment("/**/"),
-                Event::Primitive(Primitive::Identifier("a")),
-                Event::Comment("/**/"),
-                Event::Comment("/**/"),
-                Event::Primitive(Primitive::Integer(Integer::Usize(1))),
-                Event::Comment("/**/"),
-                Event::Comment("/**/"),
-                Event::Primitive(Primitive::Identifier("b")),
-                Event::Comment("/**/"),
-                Event::Comment("/**/"),
-                Event::BeginNested {
-                    name: None,
-                    kind: Nested::List
-                },
-                Event::Comment("/**/"),
-                Event::Primitive(Primitive::Integer(Integer::Usize(2))),
-                Event::Comment("/**/"),
-                Event::Comment("/**/"),
-                Event::Primitive(Primitive::Integer(Integer::Usize(3))),
-                Event::Comment("/**/"),
-                Event::EndNested,
-                Event::Comment("/**/"),
-                Event::EndNested,
-                Event::Comment("/**/"),
+                Event::new(0..4, EventKind::Comment("/**/")),
+                Event::new(
+                    4..5,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::Map
+                    }
+                ),
+                Event::new(5..9, EventKind::Comment("/**/")),
+                Event::new(9..10, EventKind::Primitive(Primitive::Identifier("a"))),
+                Event::new(10..14, EventKind::Comment("/**/")),
+                Event::new(15..19, EventKind::Comment("/**/")),
+                Event::new(
+                    19..20,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(1)))
+                ),
+                Event::new(20..24, EventKind::Comment("/**/")),
+                Event::new(25..29, EventKind::Comment("/**/")),
+                Event::new(29..30, EventKind::Primitive(Primitive::Identifier("b"))),
+                Event::new(30..34, EventKind::Comment("/**/")),
+                Event::new(35..39, EventKind::Comment("/**/")),
+                Event::new(
+                    39..40,
+                    EventKind::BeginNested {
+                        name: None,
+                        kind: Nested::List
+                    }
+                ),
+                Event::new(40..44, EventKind::Comment("/**/")),
+                Event::new(
+                    44..45,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(2)))
+                ),
+                Event::new(45..49, EventKind::Comment("/**/")),
+                Event::new(50..54, EventKind::Comment("/**/")),
+                Event::new(
+                    54..55,
+                    EventKind::Primitive(Primitive::Integer(Integer::Usize(3)))
+                ),
+                Event::new(55..59, EventKind::Comment("/**/")),
+                Event::new(59..60, EventKind::EndNested),
+                Event::new(60..64, EventKind::Comment("/**/")),
+                Event::new(64..65, EventKind::EndNested),
+                Event::new(65..69, EventKind::Comment("/**/")),
             ]
         );
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -117,6 +117,15 @@ impl Integer {
             Integer::SignedLarge(value) => value == 0,
         }
     }
+
+    pub fn as_f64(self) -> f64 {
+        match self {
+            Integer::Usize(value) => value as f64,
+            Integer::Isize(value) => value as f64,
+            Integer::UnsignedLarge(value) => value as f64,
+            Integer::SignedLarge(value) => value as f64,
+        }
+    }
 }
 
 #[cfg(feature = "integer128")]


### PR DESCRIPTION
This PR adds location information to Event, and adds basic error handling to `Parser` and `Deserializer`. I'm sure many errors can be improved, but I think this is a good start.

In theory, unless I've missed something, there should not be any `unwrap()`s outside of unit tests, and no `todo!()`s are remaining that are related to error handling. Hopefully after this is merged, there are no panics while parsing ill-formed `rsn`