### PR TITLE
Add Serialization Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ unicode-ident = "1.0.8"
 
 [dev-dependencies]
 serde = { version = "1.0.159", features = ["derive"] }
+serde_bytes = { version = "0.11.9" }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct BlogPost {
+    id: u64,
+    title: String,
+    body: String,
+    #[serde(default)]
+    previous_in_series: Option<u64>,
+    category: Category,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Category {
+    Rust,
+    Custom(String),
+}
+
+fn main() {
+    let posts: Vec<BlogPost> =
+        rsn::from_str(include_str!("./basic.rsn")).expect("error deserializing basic.rsn");
+
+    println!("Loaded blog posts: {posts:?}");
+
+    let compact = rsn::to_string(&posts);
+    println!("Compact form:\n{compact}");
+    let pretty = rsn::to_string_pretty(&posts);
+    println!("Pretty form:\n{pretty}");
+}

--- a/examples/basic.rsn
+++ b/examples/basic.rsn
@@ -1,0 +1,15 @@
+[
+    BlogPost {
+        id: 0,
+        title: "Hello, World!",
+        body: "This is a blog post.",
+        category: Custom("Welcome"),
+    },
+    BlogPost {
+        id: 1,
+        title: "I love Rust",
+        body: "Long live Ferris 🦀",
+        category: Rust,
+        previous_in_series: Some(0)
+    },
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,15 @@ pub fn to_string<S: serde::Serialize>(value: &S) -> alloc::string::String {
     serializer.finish()
 }
 
+#[cfg(feature = "serde")]
+pub fn to_string_pretty<S: serde::Serialize>(value: &S) -> alloc::string::String {
+    let mut serializer = ser::Serializer::new(writer::Config::Pretty {
+        indentation: alloc::borrow::Cow::Borrowed("  "),
+        newline: alloc::borrow::Cow::Borrowed("\n"),
+    });
+    value.serialize(&mut serializer).expect("infallible");
+    serializer.finish()
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,7 @@ pub mod writer;
 
 #[cfg(feature = "serde")]
 pub fn from_str<'de, D: serde::Deserialize<'de>>(source: &'de str) -> Result<D, de::Error> {
-    let mut parser = de::Deserializer::new(source, parser::Config::default());
-
-    let deserialized = D::deserialize(&mut parser)?;
-    parser.ensure_eof()?;
-    Ok(deserialized)
+    parser::Config::default().deserialize(source)
 }
 
 #[cfg(feature = "serde")]
@@ -32,12 +28,7 @@ pub fn to_string<S: serde::Serialize>(value: &S) -> alloc::string::String {
 
 #[cfg(feature = "serde")]
 pub fn to_string_pretty<S: serde::Serialize>(value: &S) -> alloc::string::String {
-    let mut serializer = ser::Serializer::new(writer::Config::Pretty {
-        indentation: alloc::borrow::Cow::Borrowed("  "),
-        newline: alloc::borrow::Cow::Borrowed("\n"),
-    });
-    value.serialize(&mut serializer).expect("infallible");
-    serializer.finish()
+    ser::Config::pretty().serialize(value)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,26 @@ extern crate std;
 #[cfg(feature = "serde")]
 pub mod de;
 pub mod parser;
+#[cfg(feature = "serde")]
+pub mod ser;
 pub mod tokenizer;
 pub mod value;
+pub mod writer;
 
 #[cfg(feature = "serde")]
 pub fn from_str<'de, D: serde::Deserialize<'de>>(source: &'de str) -> Result<D, de::Error> {
     let mut parser = de::Deserializer::new(source, parser::Config::default());
-    // TODO verify eof
-    D::deserialize(&mut parser)
+
+    let deserialized = D::deserialize(&mut parser)?;
+    parser.ensure_eof()?;
+    Ok(deserialized)
+}
+
+#[cfg(feature = "serde")]
+pub fn to_string<S: serde::Serialize>(value: &S) -> alloc::string::String {
+    let mut serializer = ser::Serializer::default();
+    value.serialize(&mut serializer).expect("infallible");
+    serializer.finish()
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -477,7 +477,7 @@ impl<'s> Iterator for Parser<'s> {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Config {
     pub allow_implicit_map: bool,
     pub include_comments: bool,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,122 +1,147 @@
+use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt::Display;
+use serde::Serialize;
 
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant,
 };
 
-use crate::writer::{Config, Writer};
+use crate::writer::{self, Writer};
 
 #[derive(Debug, Default)]
-pub struct Serializer {
-    writer: Writer,
+pub struct Serializer<'config> {
+    writer: Writer<'config>,
+    implicit_map_at_root: bool,
 }
 
-impl Serializer {
-    pub fn new(config: Config) -> Self {
+impl<'config> Serializer<'config> {
+    pub fn new(config: &'config Config) -> Self {
         Self {
-            writer: Writer::new(config),
+            writer: Writer::new(&config.writer),
+            implicit_map_at_root: config.implicit_map_at_root,
         }
     }
 
     pub fn finish(self) -> String {
         self.writer.finish()
     }
+
+    fn mark_value_seen(&mut self) {
+        self.implicit_map_at_root = false;
+    }
 }
 
-impl<'a> serde::Serializer for &'a mut Serializer {
+impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
     type SerializeMap = Self;
     type SerializeSeq = Self;
-    type SerializeStruct = Self;
+    type SerializeStruct = StructSerializer<'a, 'config>;
     type SerializeStructVariant = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
     type SerializeTupleVariant = Self;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(&v);
         Ok(())
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(v);
         Ok(())
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_primitive(v);
         Ok(())
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_raw_value("None");
         Ok(())
     }
@@ -125,6 +150,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     where
         T: serde::Serialize,
     {
+        self.mark_value_seen();
         self.writer.begin_named_tuple("Some");
         value.serialize(&mut *self)?;
         self.writer.finish_nested();
@@ -132,11 +158,13 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_raw_value("()");
         Ok(())
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_raw_value(name);
         Ok(())
     }
@@ -147,6 +175,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
+        self.mark_value_seen();
         self.writer.write_raw_value(variant);
         Ok(())
     }
@@ -159,6 +188,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     where
         T: serde::Serialize,
     {
+        self.mark_value_seen();
         self.writer.begin_named_tuple(name);
         value.serialize(&mut *self)?;
         self.writer.finish_nested();
@@ -175,6 +205,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     where
         T: serde::Serialize,
     {
+        self.mark_value_seen();
         self.writer.begin_named_tuple(variant);
         value.serialize(&mut *self)?;
         self.writer.finish_nested();
@@ -182,11 +213,13 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.mark_value_seen();
         self.writer.begin_list();
         Ok(self)
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.mark_value_seen();
         self.writer.begin_tuple();
         Ok(self)
     }
@@ -196,6 +229,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.mark_value_seen();
         self.writer.begin_named_tuple(name);
         Ok(self)
     }
@@ -207,11 +241,13 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.mark_value_seen();
         self.writer.begin_named_tuple(variant);
         Ok(self)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.mark_value_seen();
         self.writer.begin_map();
         Ok(self)
     }
@@ -221,8 +257,17 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        self.writer.begin_named_map(name);
-        Ok(self)
+        let is_implicit_map = self.implicit_map_at_root;
+        self.mark_value_seen();
+
+        if !is_implicit_map {
+            self.writer.begin_named_map(name);
+        }
+
+        Ok(StructSerializer {
+            serializer: self,
+            is_implicit_map,
+        })
     }
 
     fn serialize_struct_variant(
@@ -237,7 +282,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeSeq for &'a mut Serializer {
+impl<'a, 'config> SerializeSeq for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -254,7 +299,7 @@ impl<'a> SerializeSeq for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeTuple for &'a mut Serializer {
+impl<'a, 'config> SerializeTuple for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -271,7 +316,7 @@ impl<'a> SerializeTuple for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeTupleStruct for &'a mut Serializer {
+impl<'a, 'config> SerializeTupleStruct for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -288,7 +333,7 @@ impl<'a> SerializeTupleStruct for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeTupleVariant for &'a mut Serializer {
+impl<'a, 'config> SerializeTupleVariant for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -305,7 +350,44 @@ impl<'a> SerializeTupleVariant for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeStruct for &'a mut Serializer {
+pub struct StructSerializer<'a, 'config> {
+    serializer: &'a mut Serializer<'config>,
+    is_implicit_map: bool,
+}
+
+impl<'a, 'config> SerializeStruct for StructSerializer<'a, 'config> {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        if self.is_implicit_map {
+            self.serializer.writer.write_raw_value(key);
+            self.serializer.writer.write_raw_value(": ");
+            value.serialize(&mut *self.serializer)?;
+            self.serializer.writer.insert_newline();
+        } else {
+            self.serializer.writer.write_raw_value(key);
+            value.serialize(&mut *self.serializer)?;
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        if !self.is_implicit_map {
+            self.serializer.writer.finish_nested();
+        }
+        Ok(())
+    }
+}
+
+impl<'a, 'config> SerializeStructVariant for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -327,29 +409,7 @@ impl<'a> SerializeStruct for &'a mut Serializer {
     }
 }
 
-impl<'a> SerializeStructVariant for &'a mut Serializer {
-    type Error = Infallible;
-    type Ok = ();
-
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
-        self.writer.write_raw_value(key);
-        value.serialize(&mut **self)
-    }
-
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
-    }
-}
-
-impl<'a> SerializeMap for &'a mut Serializer {
+impl<'a, 'config> SerializeMap for &'a mut Serializer<'config> {
     type Error = Infallible;
     type Ok = ();
 
@@ -370,6 +430,35 @@ impl<'a> SerializeMap for &'a mut Serializer {
     fn end(self) -> Result<Self::Ok, Self::Error> {
         self.writer.finish_nested();
         Ok(())
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct Config {
+    pub writer: writer::Config,
+    pub implicit_map_at_root: bool,
+}
+
+impl Config {
+    pub fn pretty() -> Self {
+        Self {
+            writer: writer::Config::Pretty {
+                indentation: Cow::Borrowed("  "),
+                newline: Cow::Borrowed("\n"),
+            },
+            implicit_map_at_root: false,
+        }
+    }
+
+    pub const fn implicit_map_at_root(mut self, implicit_map_at_root: bool) -> Self {
+        self.implicit_map_at_root = implicit_map_at_root;
+        self
+    }
+
+    pub fn serialize<S: Serialize>(&self, value: &S) -> String {
+        let mut serializer = Serializer::new(self);
+        value.serialize(&mut serializer).expect("infallible");
+        serializer.finish()
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -6,7 +6,7 @@ use serde::ser::{
     SerializeTupleStruct, SerializeTupleVariant,
 };
 
-use crate::writer::Writer;
+use crate::writer::{Config, Writer};
 
 #[derive(Debug, Default)]
 pub struct Serializer {
@@ -14,6 +14,12 @@ pub struct Serializer {
 }
 
 impl Serializer {
+    pub fn new(config: Config) -> Self {
+        Self {
+            writer: Writer::new(config),
+        }
+    }
+
     pub fn finish(self) -> String {
         self.writer.finish()
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,400 @@
+use alloc::string::String;
+use core::fmt::Display;
+
+use serde::ser::{
+    SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+    SerializeTupleStruct, SerializeTupleVariant,
+};
+
+use crate::writer::Writer;
+
+#[derive(Debug, Default)]
+pub struct Serializer {
+    writer: Writer,
+}
+
+impl Serializer {
+    pub fn finish(self) -> String {
+        self.writer.finish()
+    }
+}
+
+impl<'a> serde::Serializer for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+    type SerializeMap = Self;
+    type SerializeSeq = Self;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(&v);
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(v);
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_primitive(v);
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_raw_value("None");
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.writer.begin_named_tuple("Some");
+        value.serialize(&mut *self)?;
+        self.writer.finish_nested();
+        Ok(())
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_raw_value("()");
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_raw_value(name);
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        self.writer.write_raw_value(variant);
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.writer.begin_named_tuple(name);
+        value.serialize(&mut *self)?;
+        self.writer.finish_nested();
+        Ok(())
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.writer.begin_named_tuple(variant);
+        value.serialize(&mut *self)?;
+        self.writer.finish_nested();
+        Ok(())
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        self.writer.begin_list();
+        Ok(self)
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        self.writer.begin_tuple();
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        self.writer.begin_named_tuple(name);
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        self.writer.begin_named_tuple(variant);
+        Ok(self)
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        self.writer.begin_map();
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        self.writer.begin_named_map(name);
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        self.writer.begin_named_map(variant);
+        Ok(self)
+    }
+}
+
+impl<'a> SerializeSeq for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeTuple for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeTupleStruct for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeTupleVariant for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeStruct for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.writer.write_raw_value(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeStructVariant for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        self.writer.write_raw_value(key);
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+impl<'a> SerializeMap for &'a mut Serializer {
+    type Error = Infallible;
+    type Ok = ();
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        key.serialize(&mut **self)
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: serde::Serialize,
+    {
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        self.writer.finish_nested();
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum Infallible {}
+
+impl serde::ser::Error for Infallible {
+    fn custom<T>(_msg: T) -> Self
+    where
+        T: core::fmt::Display,
+    {
+        unreachable!("rsn is infallible when serializing")
+    }
+}
+
+impl Display for Infallible {
+    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        unreachable!("this type cannot be constructed")
+    }
+}
+
+impl serde::ser::StdError for Infallible {}
+
+#[test]
+fn serialization_test() {
+    #[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+    struct BasicNamed {
+        a: u32,
+        b: i32,
+    }
+
+    let rendered = crate::to_string(&BasicNamed { a: 1, b: -1 });
+    assert_eq!(rendered, r#"BasicNamed{a:1,b:-1}"#);
+}

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1,6 +1,91 @@
+use alloc::borrow::Cow;
+use alloc::vec;
 use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
+struct StructOfEverything<'a> {
+    str: Cow<'a, str>,
+    bytes: serde_bytes::ByteBuf,
+    char: char,
+    u8: u8,
+    u16: u16,
+    u32: u32,
+    u64: u64,
+    u128: u128,
+    usize: usize,
+    i8: i8,
+    i16: i16,
+    i32: i32,
+    i64: i64,
+    i128: i128,
+    isize: isize,
+    bool: bool,
+}
+
+impl<'a> StructOfEverything<'a> {
+    fn min() -> Self {
+        Self {
+            str: Cow::Borrowed("\0"),
+            bytes: serde_bytes::ByteBuf::from(vec![0]),
+            char: '\0',
+            u8: 0,
+            u16: 0,
+            u32: 0,
+            u64: 0,
+            u128: 0,
+            usize: 0,
+            i8: i8::MIN,
+            i16: i16::MIN,
+            i32: i32::MIN,
+            i64: i64::MIN,
+            i128: i128::from(i64::MIN), /* To make deserialization strings consistent and compatible across feature flags */
+            isize: isize::MIN,
+            bool: false,
+        }
+    }
+
+    fn max() -> Self {
+        Self {
+            str: Cow::Borrowed("hello \u{1_F980}"),
+            bytes: serde_bytes::ByteBuf::from(b"hello, world".to_vec()),
+            char: '\u{1_F980}',
+            u8: u8::MAX,
+            u16: u16::MAX,
+            u32: u32::MAX,
+            u64: u64::MAX,
+            u128: u128::from(u64::MAX), /* To make deserialization strings consistent and compatible across feature flags */
+            usize: usize::MAX,
+            i8: i8::MAX,
+            i16: i16::MAX,
+            i32: i32::MAX,
+            i64: i64::MAX,
+            i128: i128::from(i64::MAX), /* To make deserialization strings consistent and compatible across feature flags */
+            isize: isize::MAX,
+            bool: true,
+        }
+    }
+}
+
+#[track_caller]
+fn roundtrip<T: Debug + Serialize + for<'de> Deserialize<'de> + PartialEq>(value: &T, check: &str) {
+    let rendered = crate::to_string(value);
+    #[cfg(feature = "std")]
+    {
+        std::dbg!(&rendered);
+    }
+    assert_eq!(rendered, check);
+    let restored: T = crate::from_str(&rendered).expect("deserialization failed");
+    assert_eq!(&restored, value);
+}
+
+#[test]
+fn struct_of_everything() {
+    roundtrip(&StructOfEverything::default(), "StructOfEverything{str:\"\",bytes:b\"\",char:'\\0',u8:0,u16:0,u32:0,u64:0,u128:0,usize:0,i8:0,i16:0,i32:0,i64:0,i128:0,isize:0,bool:false}");
+    roundtrip(&StructOfEverything::min(), "StructOfEverything{str:\"\\0\",bytes:b\"\\0\",char:'\\0',u8:0,u16:0,u32:0,u64:0,u128:0,usize:0,i8:-128,i16:-32768,i32:-2147483648,i64:-9223372036854775808,i128:-9223372036854775808,isize:-9223372036854775808,bool:false}");
+    roundtrip(&StructOfEverything::max(), "StructOfEverything{str:\"hello 🦀\",bytes:b\"hello, world\",char:'🦀',u8:255,u16:65535,u32:4294967295,u64:18446744073709551615,u128:18446744073709551615,usize:18446744073709551615,i8:127,i16:32767,i32:2147483647,i64:9223372036854775807,i128:9223372036854775807,isize:9223372036854775807,bool:true}");
+}
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(untagged)]

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -80,11 +80,33 @@ fn roundtrip<T: Debug + Serialize + for<'de> Deserialize<'de> + PartialEq>(value
     assert_eq!(&restored, value);
 }
 
+#[track_caller]
+fn roundtrip_pretty<T: Debug + Serialize + for<'de> Deserialize<'de> + PartialEq>(
+    value: &T,
+    check: &str,
+) {
+    let rendered = crate::to_string_pretty(value);
+    #[cfg(feature = "std")]
+    {
+        std::println!("{rendered}");
+    }
+    assert_eq!(rendered, check);
+    let restored: T = crate::from_str(&rendered).expect("deserialization failed");
+    assert_eq!(&restored, value);
+}
+
 #[test]
 fn struct_of_everything() {
     roundtrip(&StructOfEverything::default(), "StructOfEverything{str:\"\",bytes:b\"\",char:'\\0',u8:0,u16:0,u32:0,u64:0,u128:0,usize:0,i8:0,i16:0,i32:0,i64:0,i128:0,isize:0,bool:false}");
     roundtrip(&StructOfEverything::min(), "StructOfEverything{str:\"\\0\",bytes:b\"\\0\",char:'\\0',u8:0,u16:0,u32:0,u64:0,u128:0,usize:0,i8:-128,i16:-32768,i32:-2147483648,i64:-9223372036854775808,i128:-9223372036854775808,isize:-9223372036854775808,bool:false}");
     roundtrip(&StructOfEverything::max(), "StructOfEverything{str:\"hello 🦀\",bytes:b\"hello, world\",char:'🦀',u8:255,u16:65535,u32:4294967295,u64:18446744073709551615,u128:18446744073709551615,usize:18446744073709551615,i8:127,i16:32767,i32:2147483647,i64:9223372036854775807,i128:9223372036854775807,isize:9223372036854775807,bool:true}");
+}
+
+#[test]
+fn struct_of_everything_pretty() {
+    roundtrip_pretty(&StructOfEverything::default(), "StructOfEverything {\n  str: \"\",\n  bytes: b\"\",\n  char: '\\0',\n  u8: 0,\n  u16: 0,\n  u32: 0,\n  u64: 0,\n  u128: 0,\n  usize: 0,\n  i8: 0,\n  i16: 0,\n  i32: 0,\n  i64: 0,\n  i128: 0,\n  isize: 0,\n  bool: false\n}");
+    roundtrip_pretty(&StructOfEverything::min(), "StructOfEverything {\n  str: \"\\0\",\n  bytes: b\"\\0\",\n  char: '\\0',\n  u8: 0,\n  u16: 0,\n  u32: 0,\n  u64: 0,\n  u128: 0,\n  usize: 0,\n  i8: -128,\n  i16: -32768,\n  i32: -2147483648,\n  i64: -9223372036854775808,\n  i128: -9223372036854775808,\n  isize: -9223372036854775808,\n  bool: false\n}");
+    roundtrip_pretty(&StructOfEverything::max(), "StructOfEverything {\n  str: \"hello 🦀\",\n  bytes: b\"hello, world\",\n  char: '🦀',\n  u8: 255,\n  u16: 65535,\n  u32: 4294967295,\n  u64: 18446744073709551615,\n  u128: 18446744073709551615,\n  usize: 18446744073709551615,\n  i8: 127,\n  i16: 32767,\n  i32: 2147483647,\n  i64: 9223372036854775807,\n  i128: 9223372036854775807,\n  isize: 9223372036854775807,\n  bool: true\n}");
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -852,7 +852,7 @@ impl<'a, const INCLUDE_ALL: bool> Tokenizer<'a, INCLUDE_ALL> {
             match self.next_or_eof()? {
                 '"' => {
                     let range = self.chars.marked_range();
-                    let contents = &self.chars.source[range.start + 1..range.end - 1];
+                    let contents = &self.chars.source[range.start + 2..range.end - 1];
                     return Ok(Token::new(
                         range,
                         TokenKind::Bytes(Cow::Borrowed(contents.as_bytes())),
@@ -2128,6 +2128,7 @@ mod tests {
             };
         }
 
+        test_byte_string!(b"hello world");
         test_byte_string!(b"\0");
         test_byte_string!(b"\r");
         test_byte_string!(b"\t");

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,263 @@
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt::Write;
+
+#[derive(Debug, Default)]
+pub struct Writer {
+    output: String,
+    nested: Vec<NestedState>,
+}
+
+impl Writer {
+    pub fn finish(self) -> String {
+        assert!(self.nested.is_empty());
+        self.output
+    }
+
+    pub fn begin_named_map(&mut self, name: &str) {
+        self.prepare_to_write_value();
+        self.output.push_str(name);
+        self.begin_map()
+    }
+
+    pub fn begin_named_tuple(&mut self, name: &str) {
+        self.prepare_to_write_value();
+        self.output.push_str(name);
+        self.begin_tuple()
+    }
+
+    pub fn begin_map(&mut self) {
+        self.prepare_to_write_value();
+        self.output.push('{');
+        self.nested.push(NestedState::Map(MapState::Empty));
+    }
+
+    pub fn begin_tuple(&mut self) {
+        self.prepare_to_write_value();
+        self.output.push('(');
+        self.nested.push(NestedState::Tuple(SequenceState::Empty));
+    }
+
+    pub fn begin_list(&mut self) {
+        self.prepare_to_write_value();
+        self.output.push('[');
+        self.nested.push(NestedState::List(SequenceState::Empty));
+    }
+
+    pub fn write_primitive<P>(&mut self, p: &P)
+    where
+        P: Primitive + ?Sized,
+    {
+        self.prepare_to_write_value();
+        p.render_to(&mut self.output);
+    }
+
+    pub fn write_raw_value(&mut self, ident: &str) {
+        self.prepare_to_write_value();
+        self.output.push_str(ident);
+    }
+
+    fn prepare_to_write_value(&mut self) {
+        match self.nested.last_mut() {
+            Some(
+                NestedState::List(state @ SequenceState::Empty)
+                | NestedState::Tuple(state @ SequenceState::Empty),
+            ) => *state = SequenceState::NotEmpty,
+            Some(NestedState::List(_) | NestedState::Tuple(_)) => {
+                self.output.push(',');
+            }
+            Some(NestedState::Map(state @ MapState::Empty)) => *state = MapState::AfterKey,
+            Some(NestedState::Map(state @ MapState::AfterEntry)) => {
+                *state = MapState::AfterKey;
+                self.output.push(',');
+            }
+            Some(NestedState::Map(state @ MapState::AfterKey)) => {
+                *state = MapState::AfterEntry;
+                self.output.push(':');
+            }
+            None => {}
+        }
+    }
+
+    pub fn finish_nested(&mut self) {
+        match self.nested.pop().expect("not in a nested state") {
+            NestedState::Tuple(_) => self.output.push(')'),
+            NestedState::List(_) => self.output.push(']'),
+            NestedState::Map(MapState::AfterEntry | MapState::Empty) => self.output.push('}'),
+            NestedState::Map(_) => unreachable!("map entry not complete"),
+        }
+    }
+}
+
+pub trait Primitive {
+    fn render_to(&self, buffer: &mut String);
+}
+
+macro_rules! impl_primitive_using_to_string {
+    ($type:ty) => {
+        impl Primitive for $type {
+            fn render_to(&self, buffer: &mut String) {
+                buffer.push_str(&self.to_string());
+            }
+        }
+    };
+}
+
+impl_primitive_using_to_string!(u8);
+impl_primitive_using_to_string!(u16);
+impl_primitive_using_to_string!(u32);
+impl_primitive_using_to_string!(u64);
+impl_primitive_using_to_string!(u128);
+impl_primitive_using_to_string!(usize);
+impl_primitive_using_to_string!(i8);
+impl_primitive_using_to_string!(i16);
+impl_primitive_using_to_string!(i32);
+impl_primitive_using_to_string!(i64);
+impl_primitive_using_to_string!(i128);
+impl_primitive_using_to_string!(isize);
+impl_primitive_using_to_string!(f64);
+impl_primitive_using_to_string!(f32);
+
+impl Primitive for str {
+    fn render_to(&self, buffer: &mut String) {
+        buffer.reserve(self.len() + 2);
+        buffer.push('"');
+        for ch in self.chars() {
+            escape_string_char(ch, buffer);
+        }
+        buffer.push('"');
+    }
+}
+
+impl Primitive for bool {
+    fn render_to(&self, buffer: &mut String) {
+        buffer.push_str(if *self { "true" } else { "false" });
+    }
+}
+
+impl Primitive for [u8] {
+    fn render_to(&self, buffer: &mut String) {
+        buffer.reserve(self.len() + 3);
+        buffer.push_str("b\"");
+        for byte in self {
+            match DEFAULT_STRING_ESCAPE_HANDLING.get(usize::from(*byte)) {
+                Some(Some(escaped)) => {
+                    buffer.push_str(escaped);
+                }
+                Some(None) => {
+                    buffer.push(char::from(*byte));
+                }
+                None => {
+                    // Non-ASCII, must be hex-escaped.
+                    write!(buffer, "\\x{byte:02x}").expect("failed to format");
+                }
+            }
+        }
+        buffer.push('"');
+    }
+}
+
+#[inline]
+fn escape_string_char(ch: char, buffer: &mut String) {
+    if let Ok(cp) = usize::try_from(u32::from(ch)) {
+        if let Some(Some(escaped)) = DEFAULT_STRING_ESCAPE_HANDLING.get(cp) {
+            buffer.push_str(escaped);
+            return;
+        }
+    }
+
+    let mut utf8_bytes = [0; 8];
+    buffer.push_str(ch.encode_utf8(&mut utf8_bytes));
+}
+
+impl Primitive for char {
+    fn render_to(&self, buffer: &mut String) {
+        buffer.push('\'');
+        escape_string_char(*self, buffer);
+        buffer.push('\'');
+    }
+}
+
+#[rustfmt::skip]
+static DEFAULT_STRING_ESCAPE_HANDLING: [Option<&'static str>; 128] = [
+    // 0x0         1              2              3              4              5              6              7
+    Some("\\0"),   Some("\\x01"), Some("\\x02"), Some("\\x03"), Some("\\x04"), Some("\\x05"), Some("\\x06"), Some("\\x07"),
+    // 0x8         9              A              B              C              D              E              F
+    Some("\\x08"), Some("\\t"),   Some("\\n"),   Some("\\x0b"), Some("\\x0c"), Some("\\r"),   Some("\\x0e"), Some("\\x0f"),
+    // 0x10
+    Some("\\x10"), Some("\\x11"), Some("\\x12"), Some("\\x13"), Some("\\x14"), Some("\\x15"), Some("\\x16"), Some("\\x17"),
+    Some("\\x18"), Some("\\x19"), Some("\\x1a"), Some("\\x1b"), Some("\\x1c"), Some("\\x1d"), Some("\\x1e"), Some("\\x1f"),
+    // 0x20
+    None,          None,          Some("\\\""),  None,          None,          None,          None,          None,
+    None,          None,          None,          None,          None,          None,          None,          None,
+    // 0x30
+    None,          None,          None,          None,          None,          None,          None,          None,
+    None,          None,          None,          None,          None,          None,          None,          None,
+    // 0x40
+    None,          None,          None,          None,          None,          None,          None,          None,
+    None,          None,          None,          None,          None,          None,          None,          None,
+    // 0x50
+    None,          None,          None,          None,          None,          None,          None,          None,
+    None,          None,          None,          None,          Some("\\\\"),  None,          None,          None,
+    // 0x60
+    None,          None,          None,          None,          None,          None,          None,          None,
+    None,          None,          None,          None,          None,          None,          None,          None,
+    // 0x70
+    None,          None,          None,          None,          None,          None,          None,          None,
+    None,          None,          None,          None,          None,          None,          None,          Some("\\x7f"),
+];
+
+#[derive(Debug)]
+enum NestedState {
+    Tuple(SequenceState),
+    List(SequenceState),
+    Map(MapState),
+}
+
+#[derive(Debug)]
+enum SequenceState {
+    Empty,
+    NotEmpty,
+}
+
+#[derive(Debug)]
+enum MapState {
+    Empty,
+    AfterEntry,
+    AfterKey,
+}
+
+#[test]
+fn string_rendering() {
+    use crate::tokenizer::{Token, TokenKind, Tokenizer};
+    let mut to_encode = String::new();
+    for ch in 0_u8..128 {
+        to_encode.push(ch as char);
+    }
+    to_encode.push('\u{1_F980}');
+    let mut rendered = String::new();
+    to_encode.render_to(&mut rendered);
+    assert_eq!(
+        rendered,
+        "\"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f🦀\""
+    );
+    let Some(Ok(Token { kind: TokenKind::String(parsed), .. })) = Tokenizer::full(&rendered).next() else { unreachable!("failed to parse rendered string") };
+    assert_eq!(parsed, to_encode);
+}
+
+#[test]
+fn byte_rendering() {
+    use crate::tokenizer::{Token, TokenKind, Tokenizer};
+    let mut to_encode = Vec::new();
+    for ch in 0_u8..255 {
+        to_encode.push(ch);
+    }
+    let mut rendered = String::new();
+    to_encode.render_to(&mut rendered);
+    assert_eq!(
+        rendered,
+        "b\"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f\\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\\xa0\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xdf\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\""
+    );
+    let Some(Ok(Token { kind: TokenKind::Bytes(parsed), .. })) = Tokenizer::full(&rendered).next() else { unreachable!("failed to parse rendered bytes") };
+    assert_eq!(parsed, to_encode);
+}


### PR DESCRIPTION
This PR aims to offer all the serialization needs for a `serde::Serializer` implementation that supports:

- [x] condensed output
- [x] optional pretty printed output
- [x] optional implicit map at root

Additionally, the `Primitive` trait can be used to render any primitive value in its rsn-compatible form.

One opinionated thing I did in this PR: Rust allows unescaped control characters in their string literals. I don't *love* the idea of a text-based format having invisible characters in literals, so I've opted to be aggressive in escaping. This could be a good candidate for options for different encoding styles.