### PR TITLE
Implementing Value type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ serde = { version = "1.0.159", optional = true, default-features = false, featur
 ] }
 unicode-ident = "1.0.8"
 
+[[example]]
+name = "basic"
+required-features = ["serde"]
+
 [dev-dependencies]
 serde = { version = "1.0.159", features = ["derive"] }
 serde_bytes = { version = "0.11.9" }

--- a/src/de.rs
+++ b/src/de.rs
@@ -3,9 +3,9 @@ use alloc::string::{String, ToString};
 use core::fmt::Display;
 use core::iter::Peekable;
 use core::ops::Range;
-use serde::Deserialize;
 
 use serde::de::{EnumAccess, MapAccess, SeqAccess, VariantAccess};
+use serde::Deserialize;
 
 use crate::parser::{self, Config, Event, EventKind, Name, Nested, Parser, Primitive};
 use crate::tokenizer::{self, Integer};
@@ -87,25 +87,25 @@ macro_rules! deserialize_int_impl {
 impl<'de> serde::de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
-    deserialize_int_impl!(deserialize_i8, visit_i8, into_i8);
+    deserialize_int_impl!(deserialize_i8, visit_i8, as_i8);
 
-    deserialize_int_impl!(deserialize_i16, visit_i16, into_i16);
+    deserialize_int_impl!(deserialize_i16, visit_i16, as_i16);
 
-    deserialize_int_impl!(deserialize_i32, visit_i32, into_i32);
+    deserialize_int_impl!(deserialize_i32, visit_i32, as_i32);
 
-    deserialize_int_impl!(deserialize_i64, visit_i64, into_i64);
+    deserialize_int_impl!(deserialize_i64, visit_i64, as_i64);
 
-    deserialize_int_impl!(deserialize_i128, visit_i128, into_i128);
+    deserialize_int_impl!(deserialize_i128, visit_i128, as_i128);
 
-    deserialize_int_impl!(deserialize_u8, visit_u8, into_u8);
+    deserialize_int_impl!(deserialize_u8, visit_u8, as_u8);
 
-    deserialize_int_impl!(deserialize_u16, visit_u16, into_u16);
+    deserialize_int_impl!(deserialize_u16, visit_u16, as_u16);
 
-    deserialize_int_impl!(deserialize_u32, visit_u32, into_u32);
+    deserialize_int_impl!(deserialize_u32, visit_u32, as_u32);
 
-    deserialize_int_impl!(deserialize_u64, visit_u64, into_u64);
+    deserialize_int_impl!(deserialize_u64, visit_u64, as_u64);
 
-    deserialize_int_impl!(deserialize_u128, visit_u128, into_u128);
+    deserialize_int_impl!(deserialize_u128, visit_u128, as_u128);
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,6 +30,10 @@ impl<'s> Parser<'s> {
         Self::new(source, config).all(|result| result.is_ok())
     }
 
+    pub const fn current_offset(&self) -> usize {
+        self.tokens.current_offset()
+    }
+
     fn peek(&mut self) -> Option<&Token<'s>> {
         if self.peeked.is_none() {
             self.peeked = self.tokens.next();

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,12 +1,12 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
 use core::fmt::Display;
-use serde::Serialize;
 
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant,
 };
+use serde::Serialize;
 
 use crate::writer::{self, Writer};
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,6 +1,6 @@
 use alloc::borrow::Cow;
 use alloc::string::String;
-use core::fmt::Display;
+use core::fmt::Write;
 
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
@@ -10,21 +10,33 @@ use serde::Serialize;
 
 use crate::writer::{self, Writer};
 
-#[derive(Debug, Default)]
-pub struct Serializer<'config> {
-    writer: Writer<'config>,
+#[derive(Debug)]
+pub struct Serializer<'config, Output> {
+    writer: Writer<'config, Output>,
     implicit_map_at_root: bool,
 }
 
-impl<'config> Serializer<'config> {
-    pub fn new(config: &'config Config) -> Self {
+impl Default for Serializer<'static, String> {
+    fn default() -> Self {
         Self {
-            writer: Writer::new(&config.writer),
+            writer: Writer::default(),
+            implicit_map_at_root: false,
+        }
+    }
+}
+
+impl<'config, Output> Serializer<'config, Output>
+where
+    Output: Write,
+{
+    pub fn new(output: Output, config: &'config Config) -> Self {
+        Self {
+            writer: Writer::new(output, &config.writer),
             implicit_map_at_root: config.implicit_map_at_root,
         }
     }
 
-    pub fn finish(self) -> String {
+    pub fn finish(self) -> Output {
         self.writer.finish()
     }
 
@@ -33,12 +45,15 @@ impl<'config> Serializer<'config> {
     }
 }
 
-impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> serde::Serializer for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
     type SerializeMap = Self;
     type SerializeSeq = Self;
-    type SerializeStruct = StructSerializer<'a, 'config>;
+    type SerializeStruct = StructSerializer<'a, 'config, Output>;
     type SerializeStructVariant = Self;
     type SerializeTuple = Self;
     type SerializeTupleStruct = Self;
@@ -46,104 +61,87 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(&v);
-        Ok(())
+        self.writer.write_primitive(&v)
     }
 
     fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(v);
-        Ok(())
+        self.writer.write_primitive(v)
     }
 
     fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_primitive(v);
-        Ok(())
+        self.writer.write_primitive(v)
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_raw_value("None");
-        Ok(())
+        self.writer.write_raw_value("None")
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -151,22 +149,20 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         T: serde::Serialize,
     {
         self.mark_value_seen();
-        self.writer.begin_named_tuple("Some");
+        self.writer.begin_named_tuple("Some")?;
         value.serialize(&mut *self)?;
-        self.writer.finish_nested();
+        self.writer.finish_nested()?;
         Ok(())
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_raw_value("()");
-        Ok(())
+        self.writer.write_raw_value("()")
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_raw_value(name);
-        Ok(())
+        self.writer.write_raw_value(name)
     }
 
     fn serialize_unit_variant(
@@ -176,8 +172,7 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
         self.mark_value_seen();
-        self.writer.write_raw_value(variant);
-        Ok(())
+        self.writer.write_raw_value(variant)
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
@@ -189,10 +184,9 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         T: serde::Serialize,
     {
         self.mark_value_seen();
-        self.writer.begin_named_tuple(name);
+        self.writer.begin_named_tuple(name)?;
         value.serialize(&mut *self)?;
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 
     fn serialize_newtype_variant<T: ?Sized>(
@@ -206,21 +200,20 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         T: serde::Serialize,
     {
         self.mark_value_seen();
-        self.writer.begin_named_tuple(variant);
+        self.writer.begin_named_tuple(variant)?;
         value.serialize(&mut *self)?;
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         self.mark_value_seen();
-        self.writer.begin_list();
+        self.writer.begin_list()?;
         Ok(self)
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         self.mark_value_seen();
-        self.writer.begin_tuple();
+        self.writer.begin_tuple()?;
         Ok(self)
     }
 
@@ -230,7 +223,7 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         self.mark_value_seen();
-        self.writer.begin_named_tuple(name);
+        self.writer.begin_named_tuple(name)?;
         Ok(self)
     }
 
@@ -242,13 +235,13 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         self.mark_value_seen();
-        self.writer.begin_named_tuple(variant);
+        self.writer.begin_named_tuple(variant)?;
         Ok(self)
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         self.mark_value_seen();
-        self.writer.begin_map();
+        self.writer.begin_map()?;
         Ok(self)
     }
 
@@ -261,7 +254,7 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         self.mark_value_seen();
 
         if !is_implicit_map {
-            self.writer.begin_named_map(name);
+            self.writer.begin_named_map(name)?;
         }
 
         Ok(StructSerializer {
@@ -277,13 +270,16 @@ impl<'a, 'config> serde::Serializer for &'a mut Serializer<'config> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        self.writer.begin_named_map(variant);
+        self.writer.begin_named_map(variant)?;
         Ok(self)
     }
 }
 
-impl<'a, 'config> SerializeSeq for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeSeq for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -294,13 +290,15 @@ impl<'a, 'config> SerializeSeq for &'a mut Serializer<'config> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 }
 
-impl<'a, 'config> SerializeTuple for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeTuple for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -311,13 +309,15 @@ impl<'a, 'config> SerializeTuple for &'a mut Serializer<'config> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 }
 
-impl<'a, 'config> SerializeTupleStruct for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeTupleStruct for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -328,13 +328,15 @@ impl<'a, 'config> SerializeTupleStruct for &'a mut Serializer<'config> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 }
 
-impl<'a, 'config> SerializeTupleVariant for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeTupleVariant for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
@@ -345,18 +347,20 @@ impl<'a, 'config> SerializeTupleVariant for &'a mut Serializer<'config> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 }
 
-pub struct StructSerializer<'a, 'config> {
-    serializer: &'a mut Serializer<'config>,
+pub struct StructSerializer<'a, 'config, Output> {
+    serializer: &'a mut Serializer<'config, Output>,
     is_implicit_map: bool,
 }
 
-impl<'a, 'config> SerializeStruct for StructSerializer<'a, 'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeStruct for StructSerializer<'a, 'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_field<T: ?Sized>(
@@ -368,12 +372,12 @@ impl<'a, 'config> SerializeStruct for StructSerializer<'a, 'config> {
         T: serde::Serialize,
     {
         if self.is_implicit_map {
-            self.serializer.writer.write_raw_value(key);
-            self.serializer.writer.write_raw_value(": ");
+            self.serializer.writer.write_raw_value(key)?;
+            self.serializer.writer.write_raw_value(": ")?;
             value.serialize(&mut *self.serializer)?;
-            self.serializer.writer.insert_newline();
+            self.serializer.writer.insert_newline()?;
         } else {
-            self.serializer.writer.write_raw_value(key);
+            self.serializer.writer.write_raw_value(key)?;
             value.serialize(&mut *self.serializer)?;
         }
         Ok(())
@@ -381,14 +385,17 @@ impl<'a, 'config> SerializeStruct for StructSerializer<'a, 'config> {
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
         if !self.is_implicit_map {
-            self.serializer.writer.finish_nested();
+            self.serializer.writer.finish_nested()?;
         }
         Ok(())
     }
 }
 
-impl<'a, 'config> SerializeStructVariant for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeStructVariant for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_field<T: ?Sized>(
@@ -399,18 +406,20 @@ impl<'a, 'config> SerializeStructVariant for &'a mut Serializer<'config> {
     where
         T: serde::Serialize,
     {
-        self.writer.write_raw_value(key);
+        self.writer.write_raw_value(key)?;
         value.serialize(&mut **self)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
-        Ok(())
+        self.writer.finish_nested()
     }
 }
 
-impl<'a, 'config> SerializeMap for &'a mut Serializer<'config> {
-    type Error = Infallible;
+impl<'a, 'config, Output> SerializeMap for &'a mut Serializer<'config, Output>
+where
+    Output: Write,
+{
+    type Error = core::fmt::Error;
     type Ok = ();
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
@@ -428,7 +437,7 @@ impl<'a, 'config> SerializeMap for &'a mut Serializer<'config> {
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.writer.finish_nested();
+        self.writer.finish_nested()?;
         Ok(())
     }
 }
@@ -456,31 +465,11 @@ impl Config {
     }
 
     pub fn serialize<S: Serialize>(&self, value: &S) -> String {
-        let mut serializer = Serializer::new(self);
-        value.serialize(&mut serializer).expect("infallible");
+        let mut serializer = Serializer::new(String::new(), self);
+        value.serialize(&mut serializer).expect("core::fmt::Error");
         serializer.finish()
     }
 }
-
-#[derive(Debug)]
-pub enum Infallible {}
-
-impl serde::ser::Error for Infallible {
-    fn custom<T>(_msg: T) -> Self
-    where
-        T: core::fmt::Display,
-    {
-        unreachable!("rsn is infallible when serializing")
-    }
-}
-
-impl Display for Infallible {
-    fn fmt(&self, _f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        unreachable!("this type cannot be constructed")
-    }
-}
-
-impl serde::ser::StdError for Infallible {}
 
 #[test]
 fn serialization_test() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,2 +1,36 @@
 #[cfg(feature = "serde")]
 mod serde;
+
+#[macro_export]
+macro_rules! dbg {
+    () => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::dbg!()
+        }
+    }};
+    ($val:expr $(,)?) => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::dbg!($val)
+        }
+    }};
+    ($($val:expr),+ $(,)?) => {{
+        #[cfg(feature = "std")]
+        ::std::dbg!($($val),+)
+    }};
+}
+
+#[macro_export]
+macro_rules! println {
+    () => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::prinltln!()
+        }
+    }};
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "std")]
+        ::std::println!($($arg)*)
+    }};
+}

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -4,6 +4,40 @@ use core::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
+use crate::value::Value;
+
+macro_rules! dbg {
+    () => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::dbg!()
+        }
+    }};
+    ($val:expr $(,)?) => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::dbg!($val)
+        }
+    }};
+    ($($val:expr),+ $(,)?) => {{
+        #[cfg(feature = "std")]
+        ::std::dbg!($($val),+)
+    }};
+}
+
+macro_rules! println {
+    () => {{
+        #[cfg(feature = "std")]
+        {
+            ::std::prinltln!()
+        }
+    }};
+    ($($arg:tt)*) => {{
+        #[cfg(feature = "std")]
+        ::std::println!($($arg)*)
+    }};
+}
+
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 struct StructOfEverything<'a> {
     str: Cow<'a, str>,
@@ -70,11 +104,7 @@ impl<'a> StructOfEverything<'a> {
 
 #[track_caller]
 fn roundtrip<T: Debug + Serialize + for<'de> Deserialize<'de> + PartialEq>(value: &T, check: &str) {
-    let rendered = crate::to_string(value);
-    #[cfg(feature = "std")]
-    {
-        std::dbg!(&rendered);
-    }
+    let rendered = dbg!(crate::to_string(value));
     assert_eq!(rendered, check);
     let restored: T = crate::from_str(&rendered).expect("deserialization failed");
     assert_eq!(&restored, value);
@@ -86,10 +116,7 @@ fn roundtrip_pretty<T: Debug + Serialize + for<'de> Deserialize<'de> + PartialEq
     check: &str,
 ) {
     let rendered = crate::to_string_pretty(value);
-    #[cfg(feature = "std")]
-    {
-        std::println!("{rendered}");
-    }
+    println!("{rendered}");
     assert_eq!(rendered, check);
     let restored: T = crate::from_str(&rendered).expect("deserialization failed");
     assert_eq!(&restored, value);
@@ -103,10 +130,7 @@ fn roundtrip_implicit_map<T: Debug + Serialize + for<'de> Deserialize<'de> + Par
     let rendered = crate::ser::Config::pretty()
         .implicit_map_at_root(true)
         .serialize(value);
-    #[cfg(feature = "std")]
-    {
-        std::println!("{rendered}");
-    }
+    println!("{rendered}");
     assert_eq!(rendered, check);
     let restored: T = crate::parser::Config::default()
         .allow_implicit_map(true)
@@ -176,4 +200,12 @@ fn deserialize_any() {
     assert_eq!(untagged, None);
     let untagged: Option<UntaggedEnum> = crate::from_str("Some(())").unwrap();
     assert_eq!(untagged, Some(UntaggedEnum::Unit(UnitStruct)));
+}
+
+#[test]
+fn value_from_serialize() {
+    let original = StructOfEverything::default();
+    let value = dbg!(Value::from_serialize(&original));
+    let from_value: StructOfEverything = value.to_deserialize().unwrap();
+    assert_eq!(original, from_value);
 }

--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -5,38 +5,7 @@ use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
 
 use crate::value::Value;
-
-macro_rules! dbg {
-    () => {{
-        #[cfg(feature = "std")]
-        {
-            ::std::dbg!()
-        }
-    }};
-    ($val:expr $(,)?) => {{
-        #[cfg(feature = "std")]
-        {
-            ::std::dbg!($val)
-        }
-    }};
-    ($($val:expr),+ $(,)?) => {{
-        #[cfg(feature = "std")]
-        ::std::dbg!($($val),+)
-    }};
-}
-
-macro_rules! println {
-    () => {{
-        #[cfg(feature = "std")]
-        {
-            ::std::prinltln!()
-        }
-    }};
-    ($($arg:tt)*) => {{
-        #[cfg(feature = "std")]
-        ::std::println!($($arg)*)
-    }};
-}
+use crate::{dbg, println};
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
 struct StructOfEverything<'a> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -84,29 +84,29 @@ macro_rules! fn_integer_into {
 }
 
 impl Integer {
-    fn_integer_into!(into_u8, u8);
+    fn_integer_into!(as_u8, u8);
 
-    fn_integer_into!(into_u16, u16);
+    fn_integer_into!(as_u16, u16);
 
-    fn_integer_into!(into_u32, u32);
+    fn_integer_into!(as_u32, u32);
 
-    fn_integer_into!(into_u64, u64);
+    fn_integer_into!(as_u64, u64);
 
-    fn_integer_into!(into_u128, u128);
+    fn_integer_into!(as_u128, u128);
 
-    fn_integer_into!(into_usize, usize);
+    fn_integer_into!(as_usize, usize);
 
-    fn_integer_into!(into_i8, i8);
+    fn_integer_into!(as_i8, i8);
 
-    fn_integer_into!(into_i16, i16);
+    fn_integer_into!(as_i16, i16);
 
-    fn_integer_into!(into_i32, i32);
+    fn_integer_into!(as_i32, i32);
 
-    fn_integer_into!(into_i64, i64);
+    fn_integer_into!(as_i64, i64);
 
-    fn_integer_into!(into_i128, i128);
+    fn_integer_into!(as_i128, i128);
 
-    fn_integer_into!(into_isize, isize);
+    fn_integer_into!(as_isize, isize);
 
     #[inline]
     pub const fn is_zero(self) -> bool {

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,46 +1,1198 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
-use core::ops::Range;
+use core::str::{self, FromStr};
 
+use crate::parser::{Config, Error, ErrorKind, Event, EventKind, Name, Nested, Parser, Primitive};
 use crate::tokenizer::Integer;
-pub type Value<'a> = Annotated<'a, Literal<'a>>;
 pub type OwnedValue = Value<'static>;
 
-pub struct Annotated<'a, T> {
-    pub attributes: Vec<Attribute<'a>>,
-    pub location: Range<usize>,
-    pub literal: T,
-}
-pub enum Literal<'a> {
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value<'a> {
     Integer(Integer),
     Float(f64),
     Bool(bool),
     Char(char),
     Byte(u8),
+    Identifier(Cow<'a, str>),
     String(Cow<'a, str>),
     Bytes(Cow<'a, [u8]>),
-    Type(Type<'a>),
+    Named(Named<'a>),
     Tuple(List<'a>),
     Array(List<'a>),
+    Map(Map<'a>),
 }
 
-pub struct Type<'a> {
-    pub name: Identifier<'a>,
+macro_rules! as_integer {
+    ($name:ident, $ty:ty) => {
+        pub fn $name(&self) -> Option<$ty> {
+            let Self::Integer(value) = self else { return None };
+
+            value.$name()
+        }
+    };
+}
+
+impl<'a> Value<'a> {
+    as_integer!(as_u8, u8);
+
+    as_integer!(as_u16, u16);
+
+    as_integer!(as_u32, u32);
+
+    as_integer!(as_u64, u64);
+
+    as_integer!(as_u128, u128);
+
+    as_integer!(as_usize, usize);
+
+    as_integer!(as_i8, i8);
+
+    as_integer!(as_i16, i16);
+
+    as_integer!(as_i32, i32);
+
+    as_integer!(as_i64, i64);
+
+    as_integer!(as_i128, i128);
+
+    as_integer!(as_isize, isize);
+
+    pub fn from_str(source: &'a str, config: Config) -> Result<Self, Error> {
+        let mut parser = Parser::new(source, config.include_comments(false));
+        Self::parse(&mut parser)
+    }
+
+    pub const fn unit() -> Self {
+        Self::Tuple(List::new())
+    }
+
+    fn parse(parser: &mut Parser<'a>) -> Result<Self, Error> {
+        let event = parser
+            .next()
+            .transpose()?
+            .ok_or_else(|| Error::new(0..0, ErrorKind::UnexpectedEof))?; // TODO need a good location for this error
+        Self::from_parser_event(event, parser)
+    }
+
+    fn from_parser_event(event: Event<'a>, parser: &mut Parser<'a>) -> Result<Self, Error> {
+        match event.kind {
+            EventKind::BeginNested {
+                name,
+                kind: kind @ (Nested::Tuple | Nested::List),
+            } => Self::parse_sequence(name, parser, kind),
+            EventKind::BeginNested {
+                name,
+                kind: Nested::Map,
+            } => Self::parse_map(name, parser),
+            EventKind::Primitive(primitive) => match primitive {
+                Primitive::Bool(value) => Ok(Value::Bool(value)),
+                Primitive::Integer(value) => Ok(Value::Integer(value)),
+                Primitive::Float(value) => Ok(Value::Float(value)),
+                Primitive::Char(value) => Ok(Value::Char(value)),
+                Primitive::String(value) => Ok(Value::String(value)),
+                Primitive::Identifier(value) => Ok(Value::Identifier(Cow::Borrowed(value))),
+                Primitive::Bytes(value) => Ok(Value::Bytes(value)),
+            },
+            EventKind::Comment(_) => unreachable!("disabled in parser"),
+            EventKind::EndNested => unreachable!("Parser would error"),
+        }
+    }
+
+    fn parse_sequence(
+        name: Option<Name<'a>>,
+        parser: &mut Parser<'a>,
+        kind: Nested,
+    ) -> Result<Self, Error> {
+        let mut list = List::default();
+        loop {
+            let event = parser.next().expect("will error or have another event")?;
+            if matches!(event.kind, EventKind::EndNested) {
+                if let Some(name) = name {
+                    return Ok(Self::Named(Named {
+                        name: Cow::Borrowed(name.name),
+                        contents: StructContents::Tuple(list),
+                    }));
+                } else {
+                    match kind {
+                        Nested::List => return Ok(Self::Array(list)),
+                        Nested::Tuple => return Ok(Self::Tuple(list)),
+                        Nested::Map => unreachable!("parse_sequence isn't called on maps"),
+                    }
+                }
+            } else {
+                list.0.push(Self::from_parser_event(event, parser)?);
+            }
+        }
+    }
+
+    fn parse_map(name: Option<Name<'a>>, parser: &mut Parser<'a>) -> Result<Self, Error> {
+        let mut map = Map::default();
+        loop {
+            let event = parser.next().expect("will error or have another event")?;
+            if matches!(event.kind, EventKind::EndNested) {
+                if let Some(name) = name {
+                    return Ok(Self::Named(Named {
+                        name: Cow::Borrowed(name.name),
+                        contents: StructContents::Map(map),
+                    }));
+                } else {
+                    return Ok(Self::Map(map));
+                }
+            } else {
+                let key = Self::from_parser_event(event, parser)?;
+                let value = Self::from_parser_event(
+                    parser.next().expect("will error or have another event")?,
+                    parser,
+                )?;
+
+                map.0.push((key, value));
+            }
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn from_serialize<S: ::serde::Serialize>(value: &S) -> Self {
+        value.serialize(serde::ValueSerializer).expect("infallible")
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn to_deserialize<D: ::serde::Deserialize<'a>>(&self) -> Result<D, serde::Error> {
+        // TODO serde::Error needs to be exported
+        D::deserialize(serde::ValueDeserializer(self))
+    }
+
+    pub fn into_owned(self) -> Value<'static> {
+        match self {
+            Value::Integer(value) => Value::Integer(value),
+            Value::Float(value) => Value::Float(value),
+            Value::Bool(value) => Value::Bool(value),
+            Value::Char(value) => Value::Char(value),
+            Value::Byte(value) => Value::Byte(value),
+            Value::Identifier(value) => Value::Identifier(Cow::Owned(value.into_owned())),
+            Value::String(value) => Value::String(Cow::Owned(value.into_owned())),
+            Value::Bytes(value) => Value::Bytes(Cow::Owned(value.into_owned())),
+            Value::Named(value) => Value::Named(value.into_owned()),
+            Value::Tuple(value) => Value::Tuple(value.into_owned()),
+            Value::Array(value) => Value::Array(value.into_owned()),
+            Value::Map(value) => Value::Map(value.into_owned()),
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            Value::Integer(integer) => Some(integer.as_f64()),
+            Value::Float(float) => Some(*float),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Value::Identifier(str) => Some(str),
+            Value::String(str) => Some(str),
+            Value::Bytes(bytes) => str::from_utf8(bytes).ok(),
+            _ => None,
+        }
+    }
+
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            Value::Identifier(str) => Some(str.as_bytes()),
+            Value::String(str) => Some(str.as_bytes()),
+            Value::Bytes(bytes) => Some(bytes),
+            _ => None,
+        }
+    }
+}
+
+impl FromStr for Value<'static> {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Value::from_str(s, Config::default()).map(Value::into_owned)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Named<'a> {
+    pub name: Cow<'a, str>,
     pub contents: StructContents<'a>,
 }
 
+impl<'a> Named<'a> {
+    pub fn into_owned(self) -> Named<'static> {
+        Named {
+            name: Cow::Owned(self.name.into_owned()),
+            contents: self.contents.into_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum StructContents<'a> {
     Map(Map<'a>),
     Tuple(List<'a>),
 }
 
-pub struct Identifier<'a>(pub Cow<'a, str>);
+impl<'a> StructContents<'a> {
+    pub fn into_owned(self) -> StructContents<'static> {
+        match self {
+            StructContents::Map(contents) => StructContents::Map(contents.into_owned()),
+            StructContents::Tuple(contents) => StructContents::Tuple(contents.into_owned()),
+        }
+    }
+}
 
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct Map<'a>(pub Vec<(Value<'a>, Value<'a>)>);
 
+impl<'a> Map<'a> {
+    pub fn into_owned(self) -> Map<'static> {
+        Map(self
+            .0
+            .into_iter()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect())
+    }
+}
+
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct List<'a>(pub Vec<Value<'a>>);
 
-pub struct Attribute<'a> {
-    pub name: Cow<'a, str>,
-    pub contents: Cow<'a, str>,
+impl<'a> List<'a> {
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn into_owned(self) -> List<'static> {
+        List(self.0.into_iter().map(Value::into_owned).collect())
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    use alloc::borrow::Cow;
+    use alloc::string::{String, ToString};
+    use alloc::{slice, vec};
+    use core::fmt::Display;
+    use core::str;
+
+    use serde::de::{EnumAccess, MapAccess, SeqAccess, VariantAccess};
+    use serde::ser::{
+        SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    };
+    use serde::{Deserializer, Serializer};
+
+    use super::{List, StructContents};
+    use crate::parser::Nested;
+    use crate::ser::Infallible;
+    use crate::tokenizer::Integer;
+    use crate::value::{Map, Named, OwnedValue, Value};
+
+    pub struct ValueSerializer;
+
+    impl Serializer for ValueSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+        type SerializeMap = MapSerializer;
+        type SerializeSeq = SequenceSerializer;
+        type SerializeStruct = MapSerializer;
+        type SerializeStructVariant = MapSerializer;
+        type SerializeTuple = SequenceSerializer;
+        type SerializeTupleStruct = SequenceSerializer;
+        type SerializeTupleVariant = SequenceSerializer;
+
+        fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Bool(v))
+        }
+
+        fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::from(v)))
+        }
+
+        fn serialize_f32(self, v: f32) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Float(f64::from(v)))
+        }
+
+        fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Float(v))
+        }
+
+        fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Char(v))
+        }
+
+        fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::String(Cow::Owned(v.to_string())))
+        }
+
+        fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Bytes(Cow::Owned(v.to_vec())))
+        }
+
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Identifier(Cow::Borrowed("None")))
+        }
+
+        fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            Ok(Value::Named(Named {
+                name: Cow::Borrowed("Some"),
+                contents: StructContents::Tuple(List(vec![value.serialize(ValueSerializer)?])),
+            }))
+        }
+
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Tuple(List::default()))
+        }
+
+        fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Identifier(Cow::Owned(name.to_string())))
+        }
+
+        fn serialize_unit_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Identifier(Cow::Owned(variant.to_string())))
+        }
+
+        fn serialize_newtype_struct<T: ?Sized>(
+            self,
+            name: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            Ok(Value::Named(Named {
+                name: Cow::Owned(name.to_string()),
+                contents: StructContents::Tuple(List(vec![value.serialize(ValueSerializer)?])),
+            }))
+        }
+
+        fn serialize_newtype_variant<T: ?Sized>(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            Ok(Value::Named(Named {
+                name: Cow::Owned(variant.to_string()),
+                contents: StructContents::Tuple(List(vec![value.serialize(ValueSerializer)?])),
+            }))
+        }
+
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            Ok(SequenceSerializer::new(None, Nested::List))
+        }
+
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            Ok(SequenceSerializer::new(None, Nested::Tuple))
+        }
+
+        fn serialize_tuple_struct(
+            self,
+            name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            Ok(SequenceSerializer::new(
+                Some(name.to_string()),
+                Nested::Tuple,
+            ))
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Ok(SequenceSerializer::new(
+                Some(variant.to_string()),
+                Nested::Tuple,
+            ))
+        }
+
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            Ok(MapSerializer {
+                name: None,
+                contents: Map::default(),
+            })
+        }
+
+        fn serialize_struct(
+            self,
+            name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            Ok(MapSerializer {
+                name: Some(name.to_string()),
+                contents: Map::default(),
+            })
+        }
+
+        fn serialize_struct_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            Ok(MapSerializer {
+                name: Some(variant.to_string()),
+                contents: Map::default(),
+            })
+        }
+
+        fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::try_from(v).unwrap())) // TODO switch from infallible
+        }
+
+        fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
+            Ok(Value::Integer(Integer::try_from(v).unwrap())) // TODO switch from infallible
+        }
+    }
+
+    pub struct SequenceSerializer {
+        name: Option<String>,
+        kind: Nested,
+        contents: List<'static>,
+    }
+
+    impl SequenceSerializer {
+        pub fn new(name: Option<String>, kind: Nested) -> Self {
+            Self {
+                name,
+                kind,
+                contents: List::default(),
+            }
+        }
+    }
+
+    impl SerializeSeq for SequenceSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            self.contents.0.push(value.serialize(ValueSerializer)?);
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            match (self.name, self.kind) {
+                (Some(name), Nested::Tuple) => Ok(Value::Named(Named {
+                    name: Cow::Owned(name),
+                    contents: StructContents::Tuple(self.contents),
+                })),
+                (Some(name), Nested::List) => Ok(Value::Named(Named {
+                    name: Cow::Owned(name),
+                    contents: StructContents::Tuple(self.contents),
+                })),
+                (None, Nested::List) => Ok(Value::Array(self.contents)),
+                (None, Nested::Tuple) => Ok(Value::Tuple(self.contents)),
+                (_, Nested::Map) => unreachable!(),
+            }
+        }
+    }
+
+    impl SerializeTuple for SequenceSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            SerializeSeq::serialize_element(self, value)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            SerializeSeq::end(self)
+        }
+    }
+
+    impl SerializeTupleStruct for SequenceSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            SerializeSeq::serialize_element(self, value)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            SerializeSeq::end(self)
+        }
+    }
+
+    impl SerializeTupleVariant for SequenceSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            SerializeSeq::serialize_element(self, value)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            SerializeSeq::end(self)
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MapSerializer {
+        name: Option<String>,
+        contents: Map<'static>,
+    }
+
+    impl SerializeMap for MapSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            self.contents.0.push((
+                key.serialize(ValueSerializer)?,
+                Value::Tuple(List::default()),
+            ));
+            Ok(())
+        }
+
+        fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            self.contents
+                .0
+                .last_mut()
+                .expect("serialize_key not called")
+                .1 = value.serialize(ValueSerializer)?;
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            if let Some(name) = self.name {
+                Ok(Value::Named(Named {
+                    name: Cow::Owned(name),
+                    contents: StructContents::Map(self.contents),
+                }))
+            } else {
+                Ok(Value::Map(self.contents))
+            }
+        }
+    }
+
+    impl SerializeStruct for MapSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_field<T: ?Sized>(
+            &mut self,
+            key: &'static str,
+            value: &T,
+        ) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            SerializeMap::serialize_key(self, key)?;
+            SerializeMap::serialize_value(self, value)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            SerializeMap::end(self)
+        }
+    }
+
+    impl SerializeStructVariant for MapSerializer {
+        type Error = Infallible;
+        type Ok = OwnedValue;
+
+        fn serialize_field<T: ?Sized>(
+            &mut self,
+            key: &'static str,
+            value: &T,
+        ) -> Result<(), Self::Error>
+        where
+            T: serde::Serialize,
+        {
+            SerializeMap::serialize_key(self, key)?;
+            SerializeMap::serialize_value(self, value)
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            SerializeMap::end(self)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct ValueDeserializer<'a, 'de>(pub &'a Value<'de>);
+
+    macro_rules! deserialize_int {
+        ($deserialize_name:ident, $as_name:ident, $visit_name:ident) => {
+            fn $deserialize_name<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+            where
+                V: serde::de::Visitor<'de>,
+            {
+                if let Some(value) = self.0.$as_name() {
+                    visitor.$visit_name(value)
+                } else {
+                    todo!("expected i8")
+                }
+            }
+        };
+    }
+
+    impl<'a, 'de> Deserializer<'de> for ValueDeserializer<'a, 'de> {
+        type Error = Error;
+
+        deserialize_int!(deserialize_i8, as_i8, visit_i8);
+
+        deserialize_int!(deserialize_i16, as_i16, visit_i16);
+
+        deserialize_int!(deserialize_i32, as_i32, visit_i32);
+
+        deserialize_int!(deserialize_i64, as_i64, visit_i64);
+
+        deserialize_int!(deserialize_i128, as_i128, visit_i128);
+
+        deserialize_int!(deserialize_u8, as_u8, visit_u8);
+
+        deserialize_int!(deserialize_u16, as_u16, visit_u16);
+
+        deserialize_int!(deserialize_u32, as_u32, visit_u32);
+
+        deserialize_int!(deserialize_u64, as_u64, visit_u64);
+
+        deserialize_int!(deserialize_u128, as_u128, visit_u128);
+
+        deserialize_int!(deserialize_f64, as_f64, visit_f64);
+
+        fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Integer(value) => match *value {
+                    Integer::Usize(usize) => match usize::BITS {
+                        0..=16 => visitor.visit_u16(usize as u16),
+                        17..=32 => visitor.visit_u32(usize as u32),
+                        33..=64 => visitor.visit_u64(usize as u64),
+                        65..=128 => visitor.visit_u128(usize as u128),
+                        _ => unreachable!("unsupported pointer width"),
+                    },
+                    Integer::Isize(isize) => match usize::BITS {
+                        0..=16 => visitor.visit_i16(isize as i16),
+                        17..=32 => visitor.visit_i32(isize as i32),
+                        33..=64 => visitor.visit_i64(isize as i64),
+                        65..=128 => visitor.visit_i128(isize as i128),
+                        _ => unreachable!("unsupported pointer width"),
+                    },
+                    #[cfg(feature = "integer128")]
+                    Integer::UnsignedLarge(large) => visitor.visit_u128(large),
+                    #[cfg(not(feature = "integer128"))]
+                    Integer::UnsignedLarge(large) => visitor.visit_u64(large),
+                    #[cfg(feature = "integer128")]
+                    Integer::SignedLarge(large) => visitor.visit_i128(large),
+                    #[cfg(not(feature = "integer128"))]
+                    Integer::SignedLarge(large) => visitor.visit_i64(large),
+                },
+                Value::Float(value) => visitor.visit_f64(*value),
+                Value::Bool(value) => visitor.visit_bool(*value),
+                Value::Char(value) => visitor.visit_char(*value),
+                Value::Byte(value) => visitor.visit_u8(*value),
+                Value::Identifier(value) => match value {
+                    Cow::Borrowed(str) => visitor.visit_borrowed_str(str),
+                    Cow::Owned(str) => visitor.visit_str(str),
+                },
+                Value::String(value) => visitor.visit_str(value),
+                Value::Bytes(value) => match value {
+                    Cow::Borrowed(bytes) => visitor.visit_borrowed_bytes(bytes),
+                    Cow::Owned(bytes) => visitor.visit_bytes(bytes),
+                },
+                Value::Named(value) => match &value.contents {
+                    StructContents::Map(map) => visitor.visit_map(MapDeserializer::new(map)),
+                    StructContents::Tuple(list) => {
+                        visitor.visit_seq(SequenceDeserializer(list.0.iter()))
+                    }
+                },
+                Value::Array(list) | Value::Tuple(list) => {
+                    visitor.visit_seq(SequenceDeserializer(list.0.iter()))
+                }
+                Value::Map(map) => visitor.visit_map(MapDeserializer::new(map)),
+            }
+        }
+
+        fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Integer(int) => visitor.visit_bool(!int.is_zero()),
+                Value::Bool(bool) => visitor.visit_bool(*bool),
+                _ => todo!("expected bool"),
+            }
+        }
+
+        fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            if let Some(value) = self.0.as_f64() {
+                visitor.visit_f32(value as f32)
+            } else {
+                todo!("expected f32")
+            }
+        }
+
+        fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            if let Value::Char(ch) = &self.0 {
+                visitor.visit_char(*ch)
+            } else {
+                todo!("expected char")
+            }
+        }
+
+        fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::String(str) | Value::Identifier(str) => match str {
+                    Cow::Borrowed(str) => visitor.visit_borrowed_str(str),
+                    Cow::Owned(str) => visitor.visit_str(str),
+                },
+                Value::Bytes(bytes) => match bytes {
+                    Cow::Borrowed(bytes) => {
+                        if let Ok(str) = str::from_utf8(bytes) {
+                            visitor.visit_borrowed_str(str)
+                        } else {
+                            todo!("invalid utf8")
+                        }
+                    }
+                    Cow::Owned(bytes) => {
+                        if let Ok(str) = str::from_utf8(bytes) {
+                            visitor.visit_str(str)
+                        } else {
+                            todo!("invalid utf8")
+                        }
+                    }
+                },
+                Value::Named(name) => match &name.name {
+                    Cow::Borrowed(str) => visitor.visit_borrowed_str(str),
+                    Cow::Owned(str) => visitor.visit_str(str),
+                },
+                _ => todo!("expected str"),
+            }
+        }
+
+        fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_str(visitor)
+        }
+
+        fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Bytes(bytes) => match bytes {
+                    Cow::Borrowed(bytes) => visitor.visit_borrowed_bytes(bytes),
+                    Cow::Owned(bytes) => visitor.visit_bytes(bytes),
+                },
+                Value::String(str) | Value::Identifier(str) => match str {
+                    Cow::Borrowed(str) => visitor.visit_borrowed_bytes(str.as_bytes()),
+                    Cow::Owned(str) => visitor.visit_bytes(str.as_bytes()),
+                },
+                _ => todo!("expected bytes"),
+            }
+        }
+
+        fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_bytes(visitor)
+        }
+
+        fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::String(name) | Value::Identifier(name) if name == "None" => {
+                    visitor.visit_none()
+                }
+                Value::Named(Named {
+                    name,
+                    contents: StructContents::Tuple(list),
+                }) if name == "Some" && !list.0.is_empty() => {
+                    visitor.visit_some(ValueDeserializer(list.0.first().expect("length checked")))
+                }
+                // To support changing a T to Option<T>, we can fuzzily allow a
+                // value to be treated as Some(). TODO should this be optional?
+                _ => visitor.visit_some(self),
+            }
+        }
+
+        fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Named(Named {
+                    contents: StructContents::Tuple(_),
+                    ..
+                })
+                | Value::Tuple(_)
+                | Value::Array(_) => visitor.visit_unit(),
+                _ => todo!("expected unit"),
+            }
+        }
+
+        fn deserialize_unit_struct<V>(
+            self,
+            _name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_unit(visitor)
+        }
+
+        fn deserialize_newtype_struct<V>(
+            self,
+            name: &'static str,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Named(named) if named.name == name => match &named.contents {
+                    StructContents::Tuple(contents) => {
+                        if let Some(first) = contents.0.first() {
+                            visitor.visit_newtype_struct(ValueDeserializer(first))
+                        } else {
+                            visitor.visit_newtype_struct(ValueDeserializer(&Value::unit()))
+                        }
+                    }
+                    StructContents::Map(map) => {
+                        if let Some((_, first)) = map.0.first() {
+                            visitor.visit_newtype_struct(ValueDeserializer(first))
+                        } else {
+                            visitor.visit_newtype_struct(ValueDeserializer(&Value::unit()))
+                        }
+                    }
+                },
+                _ => visitor.visit_newtype_struct(self),
+            }
+        }
+
+        fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Named(Named {
+                    contents: StructContents::Tuple(list),
+                    ..
+                })
+                | Value::Tuple(list)
+                | Value::Array(list) => visitor.visit_seq(SequenceDeserializer(list.0.iter())),
+                _ => todo!("expected sequence"),
+            }
+        }
+
+        fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_seq(visitor)
+        }
+
+        fn deserialize_tuple_struct<V>(
+            self,
+            _name: &'static str,
+            len: usize,
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_tuple(len, visitor)
+        }
+
+        fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match &self.0 {
+                Value::Named(Named {
+                    contents: StructContents::Map(map),
+                    ..
+                })
+                | Value::Map(map) => visitor.visit_map(MapDeserializer::new(map)),
+                _ => todo!("expected map"),
+            }
+        }
+
+        fn deserialize_struct<V>(
+            self,
+            _name: &'static str,
+            _fields: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_map(visitor)
+        }
+
+        fn deserialize_enum<V>(
+            self,
+            _name: &'static str,
+            _variants: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            visitor.visit_enum(self)
+        }
+
+        fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_str(visitor)
+        }
+
+        fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            self.deserialize_any(visitor)
+        }
+    }
+
+    impl<'a, 'de> EnumAccess<'de> for ValueDeserializer<'a, 'de> {
+        type Error = Error;
+        type Variant = EnumVariantAccessor<'a, 'de>;
+
+        fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+        where
+            V: serde::de::DeserializeSeed<'de>,
+        {
+            match &self.0 {
+                Value::Identifier(_) | Value::String(_) => {
+                    Ok((seed.deserialize(self)?, EnumVariantAccessor::Unit))
+                }
+                Value::Named(named) => {
+                    let variant =
+                        seed.deserialize(ValueDeserializer(&Value::String(named.name.clone())))?;
+
+                    let accessor = match &named.contents {
+                        StructContents::Map(map) => EnumVariantAccessor::Map(map),
+                        StructContents::Tuple(list) => EnumVariantAccessor::Tuple(list),
+                    };
+
+                    Ok((variant, accessor))
+                }
+                _ => todo!("expected an enum"),
+            }
+        }
+    }
+
+    pub enum EnumVariantAccessor<'a, 'de> {
+        Unit,
+        Tuple(&'a List<'de>),
+        Map(&'a Map<'de>),
+    }
+
+    impl<'a, 'de> VariantAccess<'de> for EnumVariantAccessor<'a, 'de> {
+        type Error = Error;
+
+        fn unit_variant(self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+        where
+            T: serde::de::DeserializeSeed<'de>,
+        {
+            match self {
+                EnumVariantAccessor::Unit => seed.deserialize(ValueDeserializer(&Value::unit())),
+                EnumVariantAccessor::Tuple(list) => {
+                    if let Some(first) = list.0.first() {
+                        seed.deserialize(ValueDeserializer(first))
+                    } else {
+                        seed.deserialize(ValueDeserializer(&Value::unit()))
+                    }
+                }
+                EnumVariantAccessor::Map(_) => {
+                    todo!("expected newtype variant, found struct variant")
+                }
+            }
+        }
+
+        fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match self {
+                EnumVariantAccessor::Unit => visitor.visit_seq(SequenceDeserializer([].iter())),
+                EnumVariantAccessor::Tuple(list) => {
+                    visitor.visit_seq(SequenceDeserializer(list.0.iter()))
+                }
+                EnumVariantAccessor::Map(map) => visitor.visit_map(MapDeserializer::new(map)),
+            }
+        }
+
+        fn struct_variant<V>(
+            self,
+            _fields: &'static [&'static str],
+            visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::Visitor<'de>,
+        {
+            match self {
+                EnumVariantAccessor::Unit => visitor.visit_seq(SequenceDeserializer([].iter())),
+                EnumVariantAccessor::Tuple(list) => {
+                    visitor.visit_seq(SequenceDeserializer(list.0.iter()))
+                }
+                EnumVariantAccessor::Map(map) => visitor.visit_map(MapDeserializer::new(map)),
+            }
+        }
+    }
+
+    pub struct MapDeserializer<'a, 'de> {
+        map: &'a Map<'de>,
+        index: usize,
+    }
+
+    impl<'a, 'de> MapDeserializer<'a, 'de> {
+        pub fn new(map: &'a Map<'de>) -> Self {
+            Self { map, index: 0 }
+        }
+    }
+
+    impl<'a, 'de> MapAccess<'de> for MapDeserializer<'a, 'de> {
+        type Error = Error;
+
+        fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+        where
+            K: serde::de::DeserializeSeed<'de>,
+        {
+            self.map
+                .0
+                .get(self.index)
+                .map(|item| seed.deserialize(ValueDeserializer(&item.0)))
+                .transpose()
+        }
+
+        fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+        where
+            V: serde::de::DeserializeSeed<'de>,
+        {
+            let value = seed.deserialize(ValueDeserializer(&self.map.0[self.index].1))?;
+            self.index += 1;
+            Ok(value)
+        }
+    }
+
+    pub struct SequenceDeserializer<'a, 'de>(slice::Iter<'a, Value<'de>>);
+
+    impl<'a, 'de> SeqAccess<'de> for SequenceDeserializer<'a, 'de> {
+        type Error = Error;
+
+        fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+        where
+            T: serde::de::DeserializeSeed<'de>,
+        {
+            self.0
+                .next()
+                .map(|item| seed.deserialize(ValueDeserializer(item)))
+                .transpose()
+        }
+    }
+
+    #[derive(Debug)]
+
+    pub enum Error {
+        Message(String),
+    }
+
+    impl serde::de::Error for Error {
+        fn custom<T>(msg: T) -> Self
+        where
+            T: Display,
+        {
+            Self::Message(msg.to_string())
+        }
+    }
+
+    impl serde::ser::StdError for Error {}
+
+    impl Display for Error {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            match self {
+                Error::Message(message) => f.write_str(message),
+            }
+        }
+    }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,159 +1,234 @@
 use alloc::borrow::Cow;
-use alloc::string::{String, ToString};
+use alloc::fmt;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::Write;
 
-#[derive(Debug, Default)]
-pub struct Writer<'config> {
-    output: String,
+use crate::tokenizer::Integer;
+use crate::value::{StructContents, Value};
+
+#[derive(Debug)]
+pub struct Writer<'config, Output> {
+    output: Output,
     nested: Vec<NestedState>,
     config: Cow<'config, Config>,
 }
 
-impl<'config> Writer<'config> {
-    pub fn new(config: &'config Config) -> Self {
+impl Default for Writer<'static, String> {
+    fn default() -> Self {
+        Self::new(String::new(), &Config::Compact)
+    }
+}
+
+impl<'config, Output> Writer<'config, Output>
+where
+    Output: Write,
+{
+    pub fn new(output: Output, config: &'config Config) -> Self {
         Self {
-            output: String::new(),
+            output,
             nested: Vec::new(),
             config: Cow::Borrowed(config),
         }
     }
 
-    pub fn finish(self) -> String {
+    pub fn finish(self) -> Output {
         assert!(self.nested.is_empty());
         self.output
     }
 
-    pub fn begin_named_map(&mut self, name: &str) {
-        self.prepare_to_write_value();
-        self.output.push_str(name);
+    pub fn begin_named_map(&mut self, name: &str) -> fmt::Result {
+        self.prepare_to_write_value()?;
+        self.output.write_str(name)?;
         if matches!(self.config.as_ref(), Config::Pretty { .. }) {
-            self.output.push(' ');
+            self.output.write_char(' ')?;
         }
-        self.output.push('{');
+        self.output.write_char('{')?;
         self.nested.push(NestedState::Map(MapState::Empty));
+        Ok(())
     }
 
-    pub fn begin_named_tuple(&mut self, name: &str) {
-        self.prepare_to_write_value();
-        self.output.push_str(name);
-        self.output.push('(');
+    pub fn begin_named_tuple(&mut self, name: &str) -> fmt::Result {
+        self.prepare_to_write_value()?;
         self.nested.push(NestedState::Tuple(SequenceState::Empty));
+        self.output.write_str(name)?;
+        self.output.write_char('(')
     }
 
-    pub fn begin_map(&mut self) {
-        self.prepare_to_write_value();
-        self.output.push('{');
+    pub fn begin_map(&mut self) -> fmt::Result {
+        self.prepare_to_write_value()?;
         self.nested.push(NestedState::Map(MapState::Empty));
+        self.output.write_char('{')
     }
 
-    pub fn begin_tuple(&mut self) {
-        self.prepare_to_write_value();
-        self.output.push('(');
+    pub fn begin_tuple(&mut self) -> fmt::Result {
+        self.prepare_to_write_value()?;
         self.nested.push(NestedState::Tuple(SequenceState::Empty));
+        self.output.write_char('(')
     }
 
-    pub fn begin_list(&mut self) {
-        self.prepare_to_write_value();
-        self.output.push('[');
+    pub fn begin_list(&mut self) -> fmt::Result {
+        self.prepare_to_write_value()?;
         self.nested.push(NestedState::List(SequenceState::Empty));
+        self.output.write_char('[')
     }
 
-    pub fn write_primitive<P>(&mut self, p: &P)
+    pub fn write_primitive<P>(&mut self, p: &P) -> fmt::Result
     where
         P: Primitive + ?Sized,
     {
-        self.prepare_to_write_value();
-        p.render_to(&mut self.output);
+        self.prepare_to_write_value()?;
+        p.render_to(&mut self.output)
     }
 
-    pub fn write_raw_value(&mut self, ident: &str) {
-        self.prepare_to_write_value();
-        self.output.push_str(ident);
+    pub fn write_raw_value(&mut self, ident: &str) -> fmt::Result {
+        self.prepare_to_write_value()?;
+        self.output.write_str(ident)
     }
 
-    fn prepare_to_write_value(&mut self) {
+    fn prepare_to_write_value(&mut self) -> fmt::Result {
         match self.nested.last_mut() {
             Some(
                 NestedState::List(state @ SequenceState::Empty)
                 | NestedState::Tuple(state @ SequenceState::Empty),
             ) => {
                 *state = SequenceState::NotEmpty;
-                self.insert_newline();
+                self.insert_newline()?;
             }
             Some(NestedState::List(_) | NestedState::Tuple(_)) => {
-                self.output.push(',');
-                self.insert_newline();
+                self.output.write_char(',')?;
+                self.insert_newline()?;
             }
             Some(NestedState::Map(state @ MapState::Empty)) => {
                 *state = MapState::AfterKey;
-                self.insert_newline();
+                self.insert_newline()?;
             }
             Some(NestedState::Map(state @ MapState::AfterEntry)) => {
                 *state = MapState::AfterKey;
-                self.output.push(',');
-                self.insert_newline();
+                self.output.write_char(',')?;
+                self.insert_newline()?;
             }
             Some(NestedState::Map(state @ MapState::AfterKey)) => {
                 *state = MapState::AfterEntry;
                 if matches!(self.config.as_ref(), Config::Compact) {
-                    self.output.push(':');
+                    self.output.write_char(':')?;
                 } else {
-                    self.output.push_str(": ");
+                    self.output.write_str(": ")?;
                 }
             }
             None => {}
         }
+
+        Ok(())
     }
 
-    pub fn insert_newline(&mut self) {
+    pub fn insert_newline(&mut self) -> fmt::Result {
         if let Config::Pretty {
             indentation,
             newline,
             ..
         } = self.config.as_ref()
         {
-            self.output.push_str(newline);
+            self.output.write_str(newline)?;
             for _ in 0..self.nested.len() {
-                self.output.push_str(indentation);
+                self.output.write_str(indentation)?;
             }
         }
+        Ok(())
     }
 
-    pub fn finish_nested(&mut self) {
+    pub fn finish_nested(&mut self) -> fmt::Result {
         match self.nested.pop().expect("not in a nested state") {
             NestedState::Tuple(state) => {
                 if matches!(state, SequenceState::NotEmpty) {
-                    self.insert_newline();
+                    self.insert_newline()?;
                 }
-                self.output.push(')')
+                self.output.write_char(')')
             }
             NestedState::List(state) => {
                 if matches!(state, SequenceState::NotEmpty) {
-                    self.insert_newline();
+                    self.insert_newline()?;
                 }
-                self.output.push(']')
+                self.output.write_char(']')
             }
             NestedState::Map(state @ (MapState::AfterEntry | MapState::Empty)) => {
                 if matches!(state, MapState::AfterEntry) {
-                    self.insert_newline();
+                    self.insert_newline()?;
                 }
-                self.output.push('}')
+                self.output.write_char('}')
             }
             NestedState::Map(_) => unreachable!("map entry not complete"),
+        }
+    }
+
+    pub fn write_value(&mut self, value: &Value<'_>) -> fmt::Result {
+        match value {
+            Value::Integer(value) => match value {
+                Integer::Usize(value) => self.write_primitive(value),
+                Integer::Isize(value) => self.write_primitive(value),
+                Integer::UnsignedLarge(value) => self.write_primitive(value),
+                Integer::SignedLarge(value) => self.write_primitive(value),
+            },
+            Value::Float(value) => self.write_primitive(value),
+            Value::Bool(value) => self.write_primitive(value),
+            Value::Char(value) => self.write_primitive(value),
+            Value::Byte(value) => self.write_primitive(value),
+            Value::Identifier(value) => self.write_primitive(value.as_ref()),
+            Value::String(value) => self.write_primitive(value.as_ref()),
+            Value::Bytes(value) => self.write_primitive(value.as_ref()),
+            Value::Named(value) => {
+                match &value.contents {
+                    StructContents::Map(map) => {
+                        self.begin_named_map(&value.name)?;
+                        for (key, value) in &map.0 {
+                            self.write_value(key)?;
+                            self.write_value(value)?;
+                        }
+                    }
+                    StructContents::Tuple(seq) => {
+                        self.begin_named_tuple(&value.name)?;
+                        for value in &seq.0 {
+                            self.write_value(value)?;
+                        }
+                    }
+                }
+                self.finish_nested()
+            }
+            Value::Tuple(list) => {
+                self.begin_tuple()?;
+                for value in &list.0 {
+                    self.write_value(value)?;
+                }
+                self.finish_nested()
+            }
+            Value::Array(list) => {
+                self.begin_list()?;
+                for value in &list.0 {
+                    self.write_value(value)?;
+                }
+                self.finish_nested()
+            }
+            Value::Map(map) => {
+                self.begin_map()?;
+                for (key, value) in &map.0 {
+                    self.write_value(key)?;
+                    self.write_value(value)?;
+                }
+                self.finish_nested()
+            }
         }
     }
 }
 
 pub trait Primitive {
-    fn render_to(&self, buffer: &mut String);
+    fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result;
 }
 
 macro_rules! impl_primitive_using_to_string {
     ($type:ty) => {
         impl Primitive for $type {
-            fn render_to(&self, buffer: &mut String) {
-                buffer.push_str(&self.to_string());
+            fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result {
+                write!(buffer, "{self}")
             }
         }
     };
@@ -175,62 +250,59 @@ impl_primitive_using_to_string!(f64);
 impl_primitive_using_to_string!(f32);
 
 impl Primitive for str {
-    fn render_to(&self, buffer: &mut String) {
-        buffer.reserve(self.len() + 2);
-        buffer.push('"');
+    fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result {
+        buffer.write_char('"')?;
         for ch in self.chars() {
-            escape_string_char(ch, buffer);
+            escape_string_char(ch, buffer)?;
         }
-        buffer.push('"');
+        buffer.write_char('"')
     }
 }
 
 impl Primitive for bool {
-    fn render_to(&self, buffer: &mut String) {
-        buffer.push_str(if *self { "true" } else { "false" });
+    fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result {
+        buffer.write_str(if *self { "true" } else { "false" })
     }
 }
 
 impl Primitive for [u8] {
-    fn render_to(&self, buffer: &mut String) {
-        buffer.reserve(self.len() + 3);
-        buffer.push_str("b\"");
+    fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result {
+        buffer.write_str("b\"")?;
         for byte in self {
             match DEFAULT_STRING_ESCAPE_HANDLING.get(usize::from(*byte)) {
                 Some(Some(escaped)) => {
-                    buffer.push_str(escaped);
+                    buffer.write_str(escaped)?;
                 }
                 Some(None) => {
-                    buffer.push(char::from(*byte));
+                    buffer.write_char(char::from(*byte))?;
                 }
                 None => {
                     // Non-ASCII, must be hex-escaped.
-                    write!(buffer, "\\x{byte:02x}").expect("failed to format");
+                    write!(buffer, "\\x{byte:02x}")?;
                 }
             }
         }
-        buffer.push('"');
+        buffer.write_char('"')
     }
 }
 
 #[inline]
-fn escape_string_char(ch: char, buffer: &mut String) {
+fn escape_string_char<W: Write>(ch: char, buffer: &mut W) -> fmt::Result {
     if let Ok(cp) = usize::try_from(u32::from(ch)) {
         if let Some(Some(escaped)) = DEFAULT_STRING_ESCAPE_HANDLING.get(cp) {
-            buffer.push_str(escaped);
-            return;
+            return buffer.write_str(escaped);
         }
     }
 
     let mut utf8_bytes = [0; 8];
-    buffer.push_str(ch.encode_utf8(&mut utf8_bytes));
+    buffer.write_str(ch.encode_utf8(&mut utf8_bytes))
 }
 
 impl Primitive for char {
-    fn render_to(&self, buffer: &mut String) {
-        buffer.push('\'');
-        escape_string_char(*self, buffer);
-        buffer.push('\'');
+    fn render_to<W: Write>(&self, buffer: &mut W) -> fmt::Result {
+        buffer.write_char('\'')?;
+        escape_string_char(*self, buffer)?;
+        buffer.write_char('\'')
     }
 }
 
@@ -300,9 +372,9 @@ fn string_rendering() {
     for ch in 0_u8..128 {
         to_encode.push(ch as char);
     }
-    to_encode.push('\u{1_F980}');
+    to_encode.write_char('\u{1_F980}').unwrap();
     let mut rendered = String::new();
-    to_encode.render_to(&mut rendered);
+    to_encode.render_to(&mut rendered).unwrap();
     assert_eq!(
         rendered,
         "\"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f🦀\""
@@ -319,7 +391,7 @@ fn byte_rendering() {
         to_encode.push(ch);
     }
     let mut rendered = String::new();
-    to_encode.render_to(&mut rendered);
+    to_encode.render_to(&mut rendered).unwrap();
     assert_eq!(
         rendered,
         "b\"\\0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\t\\n\\x0b\\x0c\\r\\x0e\\x0f\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\x7f\\x80\\x81\\x82\\x83\\x84\\x85\\x86\\x87\\x88\\x89\\x8a\\x8b\\x8c\\x8d\\x8e\\x8f\\x90\\x91\\x92\\x93\\x94\\x95\\x96\\x97\\x98\\x99\\x9a\\x9b\\x9c\\x9d\\x9e\\x9f\\xa0\\xa1\\xa2\\xa3\\xa4\\xa5\\xa6\\xa7\\xa8\\xa9\\xaa\\xab\\xac\\xad\\xae\\xaf\\xb0\\xb1\\xb2\\xb3\\xb4\\xb5\\xb6\\xb7\\xb8\\xb9\\xba\\xbb\\xbc\\xbd\\xbe\\xbf\\xc0\\xc1\\xc2\\xc3\\xc4\\xc5\\xc6\\xc7\\xc8\\xc9\\xca\\xcb\\xcc\\xcd\\xce\\xcf\\xd0\\xd1\\xd2\\xd3\\xd4\\xd5\\xd6\\xd7\\xd8\\xd9\\xda\\xdb\\xdc\\xdd\\xde\\xdf\\xe0\\xe1\\xe2\\xe3\\xe4\\xe5\\xe6\\xe7\\xe8\\xe9\\xea\\xeb\\xec\\xed\\xee\\xef\\xf0\\xf1\\xf2\\xf3\\xf4\\xf5\\xf6\\xf7\\xf8\\xf9\\xfa\\xfb\\xfc\\xfd\\xfe\""

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,7 +1,7 @@
 use alloc::borrow::Cow;
-use alloc::fmt;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::fmt;
 use core::fmt::Write;
 
 use crate::tokenizer::Integer;


### PR DESCRIPTION
This PR adds implementations of:

- Parsing Rsn into a Value without serde
- Displaying a Value without serde
- "Parsing" a Serialize into a Value
- "Deserializing" a Value into a Deserialize

The Value type in this commit becomes a "dumb" value type, which doesn't support comments or whitespace or annotations. This is meant to be a lightweight anonymous data interchange representation. A separate type will be added to represent an Rsn document "losslessly".

- [x] Implement error handling