### PR TITLE
Added implicit map support

### DIFF
--- a/src/tests/serde.rs
+++ b/src/tests/serde.rs
@@ -1,6 +1,8 @@
 use alloc::borrow::Cow;
 use alloc::vec;
 use core::fmt::Debug;
+use std::collections::BTreeMap;
+use std::string::String;
 
 use serde::{Deserialize, Serialize};
 
@@ -235,4 +237,12 @@ fn value_from_serialize() {
     let value = dbg!(Value::from_serialize(&original));
     let from_value: StructOfEverything = value.to_deserialize().unwrap();
     assert_eq!(original, from_value);
+}
+
+#[test]
+fn implicit_btree_map() {
+    roundtrip_implicit_map(
+        &BTreeMap::from([(String::from("Hello"), 1), (String::from("World"), 2)]),
+        "\"Hello\": 1\n\"World\": 2\n",
+    );
 }


### PR DESCRIPTION
Closes #24

This refactors the implicit struct handling code to allow non-identifiers as keys. We can't use HashMap for testing because order isn't guaranteed, causing one of the assertions to fail due to it testing the serialized representation.